### PR TITLE
meshcommander: bump to 0.9.7; add github actions build/test/push workflow

### DIFF
--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -1,0 +1,100 @@
+name: Build, Test, and Push Package
+
+# Manual-dispatch loop for building one Chocolatey package, installing it on a
+# fresh Windows runner, verifying the install registers in the registry,
+# uninstalling, and (optionally) pushing to community.chocolatey.org.
+#
+# Required repo secrets when `publish: true`:
+#   CHOCO_API_KEY  - chocolatey.org community feed API key
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package directory under automatic/ (e.g. meshcommander)'
+        required: true
+        type: string
+        default: 'meshcommander'
+      run_au:
+        description: 'Run update.ps1 first to refresh URL/checksum from vendor'
+        type: boolean
+        required: true
+        default: true
+      publish:
+        description: 'Push to chocolatey.org after a successful test'
+        type: boolean
+        required: true
+        default: false
+
+jobs:
+  build-test-push:
+    runs-on: windows-2022
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      PACKAGE: ${{ inputs.package }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate package directory exists
+        run: |
+          $dir = "automatic/$env:PACKAGE"
+          if (-not (Test-Path $dir)) { throw "Package directory not found: $dir" }
+          Write-Host "Building package from $dir"
+
+      - name: Run AU update.ps1 (refresh URL/checksum from vendor)
+        if: ${{ inputs.run_au }}
+        working-directory: automatic/${{ inputs.package }}
+        run: |
+          Import-Module $env:GITHUB_WORKSPACE\AU\AU.psm1 -Force
+          ./update.ps1
+
+      - name: Pack
+        working-directory: automatic/${{ inputs.package }}
+        run: |
+          choco pack --out $env:RUNNER_TEMP
+          Get-ChildItem $env:RUNNER_TEMP\*.nupkg | ForEach-Object {
+            Write-Host "Built: $($_.Name) ($([math]::Round($_.Length/1KB,1)) KB)"
+          }
+
+      - name: Install package from local source
+        run: |
+          choco install $env:PACKAGE `
+            --source "$env:RUNNER_TEMP;https://community.chocolatey.org/api/v2/" `
+            --confirm --no-progress
+
+      - name: Verify install registered in Windows registry
+        run: |
+          $found = Get-ItemProperty `
+            'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*', `
+            'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' `
+            -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -match $env:PACKAGE }
+          if (-not $found) {
+            throw "$env:PACKAGE not found in registry after install"
+          }
+          $found | Select-Object DisplayName, DisplayVersion, Publisher | Format-Table
+
+      - name: Uninstall
+        run: choco uninstall $env:PACKAGE --confirm --no-progress
+
+      - name: Push to chocolatey.org community feed
+        if: ${{ inputs.publish }}
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          if (-not $env:CHOCO_API_KEY) { throw 'CHOCO_API_KEY repo secret is not set' }
+          $nupkg = (Get-ChildItem $env:RUNNER_TEMP\*.nupkg | Select-Object -First 1).FullName
+          choco apikey --key $env:CHOCO_API_KEY --source 'https://push.chocolatey.org/'
+          choco push $nupkg --source 'https://push.chocolatey.org/' --timeout 300
+
+      - name: Upload nupkg artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.package }}-nupkg
+          path: ${{ runner.temp }}/*.nupkg
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository purpose
+
+This repo bundles **two related concerns**:
+
+1. **The `AU/` PowerShell module** — Chocolatey Automatic Package Updater framework (forked from majkinetor/au; upstream development finished at `2022.10.24`).
+2. **`automatic/` Chocolatey packages** that consume the AU module to keep themselves up-to-date (e.g. `filebeat-oss`, `dell-dract`, `meshcommander`, `fonts-poppins`, ...).
+
+When making changes, keep clear which side you're touching: the framework code (`AU/`, `tests/`, `build.ps1`, `publish.ps1`) versus an individual package's `update.ps1` and `tools/` scripts.
+
+## Common commands
+
+All scripts run from the repo root and require **PowerShell 5+** (PowerShell 7 / pwsh works on Linux too — `update_all.ps1` already uses pwsh-only ternary syntax).
+
+| Task                                              | Command                                |
+| :------------------------------------------------ | :------------------------------------- |
+| One-time dev setup (chocolatey, pester, etc.)     | `./setup.ps1`                          |
+| Build module → `_build/<version>/`                | `./build.ps1`                          |
+| Build with explicit version                       | `./build.ps1 -Version 0.0.1`           |
+| Build + install in system                         | `./build.ps1 -Install -ShortVersion`   |
+| Install latest build                              | `./install.ps1`                        |
+| Uninstall module                                  | `./install.ps1 -Remove`                |
+| Run all tests (Pester + Chocolatey package test)  | `./test.ps1`                           |
+| Pester tests only                                 | `./test.ps1 -Pester`                   |
+| Pester with tag filter / coverage                 | `./test.ps1 -Pester -Tag <tag> -CodeCoverage` |
+| Update all packages in `automatic/`               | `./update_all.ps1`                     |
+| Force-update specific packages (smoke test)       | `./test_all.ps1 -ForcedPackages 'pkg1 pkg2'` |
+| Update one package                                | `cd automatic/<pkg>; ./update.ps1`     |
+| Force one package update                          | `$au_Force = $true; ./update.ps1`      |
+| Preview changes without writing                   | `$au_WhatIf = $true; ./update.ps1`     |
+| Clean build artifacts                             | `git clean -Xfd -e vars.ps1`           |
+
+`./test.ps1` requires a build to exist first (it reads `_build/*`). Run `./build.ps1` before testing.
+
+Publishing (rare, framework only): `./publish.ps1 -Version <v> -Tag -Github -PSGallery -Chocolatey`. Requires `vars.ps1` (copy from `vars_default.ps1`) with API keys, and a `## <version>` section in `CHANGELOG.md` for release notes.
+
+## AU module architecture
+
+The module loads via `AU/AU.psm1`, which dot-sources every `.ps1` under `AU/Private/` then `AU/Public/`. Public functions are the user-facing API; Private files are helpers (`check_url.ps1`, `is_version.ps1`, `AUVersion.ps1`, `AUPackage.ps1`, ...).
+
+### The two-function contract every package follows
+
+A package's `update.ps1` defines two `global:au_*` functions and then calls `update` (alias for `Update-Package`):
+
+- **`au_GetLatest`** — fetches remote info; returns a hashtable with at least `Version` and one of `URL32`/`URL64`. Optional `Checksum32/64`, `ChecksumType32/64`. May return `Streams = [ordered]@{ ... }` for multi-version packages — stream state persists in `<package>.json`.
+- **`au_SearchReplace`** — returns `@{ "<file>" = @{ "<regex>" = "<replacement>" } }`. Regex match is **per-line** (multi-line regex won't work). The nuspec version is replaced automatically — don't include it.
+
+Optional hooks: `au_BeforeUpdate` (runs after fetch, before file edits — common place to call `Get-RemoteFiles -Purge` for embedded packages or `Get-RemoteChecksum` for manual hashing) and `au_AfterUpdate`.
+
+`Update-Package` performs validation (URL existence + MIME type, regex pattern existence, Chocolatey gallery duplicate check) before writing. Failure of any check aborts the update — this is a feature, not a bug. Disable selectively with `-NoCheckUrl`, `-NoCheckChocoVersion`, `-ChecksumFor none`.
+
+### Automatic checksums caveat
+
+`-ChecksumFor all|32|64` works by **monkey-patching `Get-ChocolateyWebFile`** and invoking `tools/chocolateyInstall.ps1`. The install script is **terminated** at the first call to `Get-ChocolateyWebFile` — anything after that line will not run during checksum calculation. If `chocolateyInstall.ps1` does meaningful work before the download call, use `-ChecksumFor none` plus `Get-RemoteChecksum` in `au_BeforeUpdate` instead. On Linux, **always** use `-ChecksumFor none`.
+
+### Global override variables
+
+Any `Update-Package` parameter can be set via `$global:au_<ParamName>` (e.g. `$au_Force`, `$au_WhatIf`, `$au_NoCheckUrl`, `$au_IncludeStream`, `$au_Version`). Used heavily for ad-hoc overrides without editing `update.ps1`. `$au_Root` sets where `updateall` searches for packages (`update_all.ps1` and `test_all.ps1` set it to `$PSScriptRoot/automatic`).
+
+### Plugins (`AU/Plugins/`)
+
+`Update-AUPackages` (alias `updateall`) runs after a multi-package update. Any key in the `$Options` hashtable whose value is itself a `[HashTable]` and which matches a `.ps1` filename in `AU/Plugins/` (or a path in `$Options.PluginPath`) is treated as a plugin. Order in `[ordered]@{}` is the execution order. Plugins receive their hashtable plus an injected `$Info` argument with run results. Built-ins: `Gist`, `Git`, `GitLab`, `GitReleases`, `Gitter`, `History`, `Mail`, `PullRequest`, `Report`, `RunInfo`, `Snippet`. Most are configured via `$Env:*` variables (see `update_all.ps1` and `Plugins.md`).
+
+`Report` has its own subdirectory (`AU/Plugins/Report/`) with `markdown.ps1` / `text.ps1` formatters and embedded status icons.
+
+### Package conventions
+
+- Prefix a package directory with `_` to exclude it from `updateall`.
+- An `update.ps1` returning the literal string `'ignore'` (or `au_GetLatest` returning `'ignore'` for a stream) flags that run as ignored rather than failed — used for known transient errors. `IgnoreOn` / `RepeatOn` arrays in `$Options` apply this globally by error-message substring without per-package changes.
+- For metapackages depending on another AU package, dot-source the dependency's `update.ps1` and override `au_SearchReplace`. The dependent script must guard its `update` call: `if ($MyInvocation.InvocationName -ne '.') { update ... }`.
+
+## Testing
+
+Pester tests live in `tests/` and exercise the framework, not the packages:
+
+- `Update-Package.Tests.ps1`, `Update-Package.Streams.Tests.ps1` — single-package update behavior.
+- `Update-AUPackages.Tests.ps1`, `Update-AUPackages.Streams.Tests.ps1` — multi-package orchestration.
+- `Get-Version.Tests.ps1`, `AUPackage.Tests.ps1`, `General.Tests.ps1` — units.
+- Fixture directories `tests/test_package/` and `tests/test_package_with_streams/` are scaffolds the tests copy and mutate.
+
+Tests are pinned to **Pester 4.10.1** (see `setup.ps1`). Pester 5 syntax will not work.
+
+`Test-Package` (in `AU/Public/`) is a runtime helper for maintainers to dry-run a package's install/uninstall — it's also used by `test.ps1`'s `-Chocolatey` mode against the latest build.
+
+## Chocolatey package of AU itself
+
+`chocolatey/` packages the AU module for distribution via `cinst au`. `build.ps1` invokes `chocolatey/build-package.ps1` and moves the resulting `.nupkg` into `_build/<version>/`.

--- a/automatic/meshcommander/meshcommander.nuspec
+++ b/automatic/meshcommander/meshcommander.nuspec
@@ -2,29 +2,29 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
     <metadata>
         <id>meshcommander</id>
-        <version>0.9.6</version>
+        <version>0.9.7</version>
         <title>MeshCommander</title>
         <authors>Ylian Saint-Hilaire</authors>
         <owners>opnsrc.dev</owners>
-        <projectUrl>https://www.meshcommander.com/meshcommander</projectUrl>
+        <projectUrl>https://www.meshcommander.com/</projectUrl>
         <iconUrl>https://rawcdn.githack.com/mkopnsrc/chocolatey-packages/aee32a64da34a84167821b9274aac353b7a9deba/icons/MeshCommander.png</iconUrl>
-        <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/filebeat-oss</packageSourceUrl>
+        <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/meshcommander</packageSourceUrl>
         <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <releaseNotes>https://www.meshcommander.com/meshcommander</releaseNotes>
+        <releaseNotes>https://github.com/Ylianst/MeshCommander/releases</releaseNotes>
         <language>en-US</language>
         <bugTrackerUrl>https://github.com/Ylianst/MeshCommander/issues</bugTrackerUrl>
         <tags>meshcommander intelamt vpro ipmi remote management open-source</tags>
-		 <description>
+         <description>
 ## MeshCommander
 MeshCommander is a remote management tool of your Intel® AMT computers. For the first time, Intel AMT can be managed entirely from a browser, opening up many new possibilities and making it significantly easier to take advantage of hardware management provided by Intel® vPro.
 
-MeshCommander is the ultimate open source Intel® AMT management console. In an effort to make Intel® AMT easier, support many platforms and over the Internet usages, MeshCommander is entirely built in JavaScript. 
-You can now manage your Intel® AMT (vPro) computers from within a browser or as a standalone tool. 
+MeshCommander is the ultimate open source Intel® AMT management console. In an effort to make Intel® AMT easier, support many platforms and over the Internet usages, MeshCommander is entirely built in JavaScript.
+You can now manage your Intel® AMT (vPro) computers from within a browser or as a standalone tool.
         </description>
         <summary>MeshCommander is can now manage your Intel® AMT (vPro) computers from within a browser or as a standalone tool.</summary>
     </metadata>
-	<files>
-    <file src="tools\**" target="tools" />
-  </files>
+    <files>
+        <file src="tools\**" target="tools" />
+    </files>
 </package>

--- a/automatic/meshcommander/tools/chocolateyInstall.ps1
+++ b/automatic/meshcommander/tools/chocolateyInstall.ps1
@@ -1,37 +1,29 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsDir\helpers.ps1
 
 $packageArgs = @{
-	packageName     = $env:ChocolateyPackageName
-	softwareName    = 'MeshCommander*'
-  version         = $env:ChocolateyPackageVersion
-	unzipLocation   = $toolsDir
-	installerType   = 'msi'
-	url             = 'https://meshcentral.com/info/extra/mdtk/MeshCommander.msi'
-	#url64bit        = ''
-	checksum        = 'E284FA77A20B57D62A998078142EECD9F2C985BEFE32B948BD69E2D355ECF9E1'
-	checksumType    = 'SHA256'
-	#checksum64      = ''
-	#checksumType64  = 'SHA256'
-	silentArgs      = '/qn /norestart ADDLOCAL="MeshCommanderConsoleSccmExt"'
-	#Exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
-  validExitCodes = @(
-    0, # success
-    3010, # success, restart required
-    2147781575, # pending restart required
-    2147205120  # pending restart required for setup update
-  )
+    packageName     = $env:ChocolateyPackageName
+    softwareName    = 'MeshCommander*'
+    version         = $env:ChocolateyPackageVersion
+    unzipLocation   = $toolsDir
+    installerType   = 'msi'
+    url             = 'https://www.meshcommander.com/Releases/MeshCommander-0.9.7.msi'
+    checksum        = 'ad8ddf812eaa3532ce3a63651cab0c8110d071412c366b3491c9ecd2d03adfb4'
+    checksumType    = 'SHA256'
+    silentArgs      = '/qn /norestart'
+    validExitCodes  = @(
+        0,           # success
+        3010,        # success, restart required
+        2147781575,  # pending restart required
+        2147205120   # pending restart required for setup update
+    )
 }
 
 $alreadyInstalled = (AlreadyInstalled -AppName $packageArgs['softwareName'] -AppVersion $packageArgs['version'])
 
 if ($alreadyInstalled -and ($env:ChocolateyForce -ne $true)) {
-  Write-Output $(
-    $packageArgs['softwareName']+" is already installed. " +
-    'if you want to re-install, use "--force" option to re-install.'
-  )
+    Write-Output ($packageArgs['softwareName'] + ' is already installed. Use --force to re-install.')
 } else {
-	Install-ChocolateyPackage @packageArgs
-
+    Install-ChocolateyPackage @packageArgs
 }

--- a/automatic/meshcommander/update.ps1
+++ b/automatic/meshcommander/update.ps1
@@ -1,43 +1,38 @@
 Import-Module au
 
-$releases = 'https://www.meshcommander.com/meshcommander'
+$domain       = 'https://www.meshcommander.com'
+$releases     = "$domain/"
 $ChecksumType = 'SHA256'
+
 function global:au_BeforeUpdate {
     $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32
-    #$Latest.Checksum64 = Get-RemoteChecksum $Latest.URL64 -Algorithm $Latest.ChecksumType64
-
-    #AU function Get-RemoteFiles can download files and save them in the package's tools directory. It does that by using the $Latest.URL32 and/or $Latest.URL64.
-    #Get-RemoteFiles -Purge
 }
+
 function global:au_GetLatest() {
     $download_page = Invoke-WebRequest $releases -UseBasicParsing
-    $url_obj   = $download_page.links | Where-Object href -match '.msi'
-    #$url64 = $download_page.links | ? href -match '\windows-x86_64.msi$' | select -First 1 -expand href
-    $url = (Invoke-WebRequest $url_obj.href).Links |Select-Object -First 1 -ExpandProperty href
-    $version = (($url_obj.outerHTML) | Select-String '\d+(?:\.\d+)+').Matches.Value
-    $ext = $url.Split('.') |Select-Object -Last 1
-    $Latest = @{
-        InstallerType = $ext
-        URL32     = $url
-        #URL64     = $url64
-        Version   = $version
+    $href = $download_page.Links |
+        Where-Object href -match 'Releases/MeshCommander-\d+(?:\.\d+)+\.msi$' |
+        Select-Object -First 1 -ExpandProperty href
+    if (-not $href) { throw "No MeshCommander MSI link found on $releases" }
+
+    $url     = "$domain/$($href.TrimStart('/'))"
+    $version = ($href | Select-String '\d+(?:\.\d+)+').Matches.Value
+
+    @{
+        URL32          = $url
+        Version        = $version
         ChecksumType32 = $ChecksumType
-        #ChecksumType64 = $ChecksumType
     }
-    return $Latest
 }
+
 function global:au_SearchReplace {
     @{
-      ".\tools\chocolateyInstall.ps1" = @{
-        "(?i)(^\s*installerType\s*=\s*)('.*')" = "`$1'$($Latest.InstallerType)'"
-        "(?i)(^\s*url\s*=\s*)('.*')" = "`$1'$($Latest.URL32)'"
-        #"(?i)(^\s*url64bit\s*=\s*)('.*')" = "`$1'$($Latest.URL64)'"
-        "(?i)(^\s*checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-        "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
-        #"(?i)(^\s*checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
-        #"(?i)(^\s*checksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
-      };
-
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(?i)(^\s*url\s*=\s*)('.*')"          = "`$1'$($Latest.URL32)'"
+            "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+        }
     }
 }
-update -ChecksumFor none #-NoCheckChocoVersion
+
+update -ChecksumFor none


### PR DESCRIPTION
## Summary

- Rewrites `automatic/meshcommander/update.ps1` to scrape `meshcommander.com/` root for `Releases/MeshCommander-X.Y.Z.msi` (the previous `/meshcommander` page returns 404, and the previously pinned `meshcentral.com/info/extra/mdtk/MeshCommander.msi` URL is also 404).
- Bumps `meshcommander.nuspec` 0.9.6 → 0.9.7. Also fixes broken `projectUrl`, `releaseNotes`, and the `packageSourceUrl` (which pointed at `filebeat-oss`).
- Bakes the 0.9.7 URL + SHA256 into `tools/chocolateyInstall.ps1`. Drops the restrictive `ADDLOCAL=\"MeshCommanderConsoleSccmExt\"` from `silentArgs` so the default install gets all features (matches the package id).
- Adds `.github/workflows/package-build-test.yml` — a manually-dispatched workflow that runs AU `update.ps1`, `choco pack`, installs on a fresh `windows-2022` runner, registry-verifies, uninstalls, and optionally pushes to chocolatey.org. Reads `CHOCO_API_KEY` repo secret only when `publish=true`.

## Test plan

Before merging:

- [ ] Repo secret `CHOCO_API_KEY` is set (Settings → Secrets and variables → Actions)
- [ ] Run workflow manually (Actions → \"Build, Test, and Push Package\" → Run workflow) with defaults: \`package=meshcommander\`, \`run_au=true\`, \`publish=false\` — dry run, confirms pack/install/uninstall succeed on a fresh runner
- [ ] Re-run with \`publish=true\` to push 0.9.7 to chocolatey.org community moderation queue
- [ ] Confirm package appears at https://community.chocolatey.org/packages/meshcommander after moderation

## Notes

- AU's choco-version check is intentionally left on; it prevents republishing duplicate versions and short-circuits if 0.9.7 already exists on the gallery.
- Multi-version backfill (e.g. Beats 8.14.1 → 9.3.3 spanning many releases) is **not** addressed here — that needs a separate orchestration script. This PR establishes the single-package single-version loop first.