### PR TITLE
workflow: fix AU module import (use install.ps1, bump actions to v5)

### DIFF
--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -37,7 +37,7 @@ jobs:
       PACKAGE: ${{ inputs.package }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate package directory exists
         run: |
@@ -45,12 +45,14 @@ jobs:
           if (-not (Test-Path $dir)) { throw "Package directory not found: $dir" }
           Write-Host "Building package from $dir"
 
+      - name: Install AU module to PSModulePath
+        run: |
+          & "$env:GITHUB_WORKSPACE\install.ps1" -module_path "$env:GITHUB_WORKSPACE\AU"
+
       - name: Run AU update.ps1 (refresh URL/checksum from vendor)
         if: ${{ inputs.run_au }}
         working-directory: automatic/${{ inputs.package }}
-        run: |
-          Import-Module $env:GITHUB_WORKSPACE\AU\AU.psm1 -Force
-          ./update.ps1
+        run: ./update.ps1
 
       - name: Pack
         working-directory: automatic/${{ inputs.package }}
@@ -93,7 +95,7 @@ jobs:
 
       - name: Upload nupkg artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ inputs.package }}-nupkg
           path: ${{ runner.temp }}/*.nupkg


### PR DESCRIPTION
## Summary

Fixes the failed step from PR #16's first dry run.

The path-based \`Import-Module \$env:GITHUB_WORKSPACE\AU\AU.psm1\` didn't register the module under the name \`au\` because the source tree has no \`.psd1\` manifest (\`build.ps1\` generates it at build time). \`update.ps1\`'s subsequent \`Import-Module au\` then failed with \"no valid module file was found\".

This PR switches to the repo's existing \`install.ps1\` to copy AU into the pwsh 7 system module path (\`C:\Program Files\PowerShell\7\Modules\AU\`), so \`Import-Module au\` resolves normally via PSModulePath.

Also bumps \`actions/checkout\` and \`actions/upload-artifact\` to \`@v5\` to silence the Node 20 deprecation warning that fired on the previous run.

## Test plan

- [ ] Merge this, then dispatch \"Build, Test, and Push Package\" with defaults (\`package=meshcommander\`, \`run_au=true\`, \`publish=false\`)
- [ ] All 8 steps reach green (Set up → Checkout → Validate → Install AU → Run update.ps1 → Pack → Install → Verify → Uninstall → Upload artifact)