### PR TITLE
workflow: include package version in nupkg artifact name

### DIFF
--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Pack
         working-directory: automatic/${{ inputs.package }}
         run: |
+          [xml]$nuspec = Get-Content "$env:PACKAGE.nuspec"
+          $version = $nuspec.package.metadata.version
+          "PACKAGE_VERSION=$version" >> $env:GITHUB_ENV
+          Write-Host "Version: $version"
           choco pack --out $env:RUNNER_TEMP
           Get-ChildItem $env:RUNNER_TEMP\*.nupkg | ForEach-Object {
             Write-Host "Built: $($_.Name) ($([math]::Round($_.Length/1KB,1)) KB)"
@@ -94,9 +98,9 @@ jobs:
           choco push $nupkg --source 'https://push.chocolatey.org/' --timeout 300
 
       - name: Upload nupkg artifact
-        if: always()
+        if: always() && env.PACKAGE_VERSION != ''
         uses: actions/upload-artifact@v5
         with:
-          name: ${{ inputs.package }}-nupkg
+          name: ${{ inputs.package }}-${{ env.PACKAGE_VERSION }}-nupkg
           path: ${{ runner.temp }}/*.nupkg
           retention-days: 14


### PR DESCRIPTION
## Summary

Reads the version from the nuspec at the start of the Pack step, exposes it as a `PACKAGE_VERSION` env var, and uses it in the artifact name.

Before: artifact named `meshcommander-nupkg` — every run overwrites the same name in the Artifacts UI.
After: artifact named `meshcommander-0.9.7-nupkg` — historical runs stay distinguishable.

## Implementation notes

- Version is read from the nuspec rather than the produced nupkg filename, so it's available before `choco pack` runs.
- Upload step is gated on `env.PACKAGE_VERSION != ''` so a Pack-step failure before the nuspec read produces no malformed (empty-version) artifact name.
- When `inputs.run_au=true`, version is read AFTER `update.ps1` has potentially bumped the nuspec, capturing the new version.

## Test plan

- [ ] Merge, dispatch with defaults — confirm artifact appears as `<package>-<version>-nupkg`
- [ ] Verify the version shown in step logs matches the nupkg filename