### PR TITLE
backfill: per-target direct-key CCR status check (conservative gate)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -66,40 +66,71 @@ jobs:
               continue
             }
 
-            $url = "https://community.chocolatey.org/api/v2/Packages?`$filter=Id eq '$pkg'&`$orderby=Version desc&`$top=50"
-            try {
-              $response = Invoke-WebRequest -Uri $url -UseBasicParsing -UserAgent 'mkopnsrc-backfill/1.0'
-            } catch {
-              Write-Host "::warning::$pkg : CCR query failed ($_); skipping"
-              continue
+            # CCR's OData feed returns inconsistent statuses across query paths
+            # during moderation: the direct-key endpoint may show Approved while
+            # the $filter endpoint still shows Submitted/Pending for the same
+            # Id+Version. We query BOTH and take the more conservative status —
+            # if either says Pending, we wait. This matches the user-facing
+            # behaviour where a package isn't fully published until both indices
+            # agree it is Approved.
+            function Get-CcrStatus($url) {
+              try {
+                $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -UserAgent 'mkopnsrc-backfill/1.0'
+                $m = [regex]::Match($resp.Content, '<d:PackageStatus[^>]*>([^<]+)</d:PackageStatus>')
+                if ($m.Success) { return $m.Groups[1].Value.Trim() }
+                if ($resp.Content -match '<entry>') { return 'Unknown' }
+                return $null
+              } catch {
+                if ($_.Exception.Response.StatusCode.value__ -eq 404 -or $_.Exception.Message -match '404') {
+                  return $null
+                }
+                throw
+              }
             }
 
-            [xml]$xml = $response.Content
-            $existing = @{}
-            foreach ($entry in $xml.feed.entry) {
-              $v = $entry.properties.Version
-              $s = $entry.properties.PackageStatus
-              if ($v) { $existing[[string]$v] = [string]$s }
+            $statuses = [ordered]@{}
+            foreach ($v in $targets) {
+              $directUrl = "https://community.chocolatey.org/api/v2/Packages(Id='$pkg',Version='$v')"
+              $filterUrl = "https://community.chocolatey.org/api/v2/Packages?`$filter=Id eq '$pkg' and Version eq '$v'"
+              try {
+                $direct = Get-CcrStatus $directUrl
+                $filter = Get-CcrStatus $filterUrl
+              } catch {
+                Write-Host "::warning::$pkg : CCR check for $v failed ($_); treating as unknown"
+                $statuses[$v] = 'Unknown'
+                continue
+              }
+              # Combine: most conservative wins
+              $statuses[$v] = if ($direct -eq $null -and $filter -eq $null) { $null }
+                              elseif ($direct -in @('Submitted','Pending') -or $filter -in @('Submitted','Pending')) { 'Pending' }
+                              elseif ($direct -eq 'Rejected' -or $filter -eq 'Rejected') { 'Rejected' }
+                              elseif ($direct -eq 'Approved' -and $filter -eq 'Approved') { 'Approved' }
+                              else { 'Unknown' }
             }
 
-            $statusSummary = if ($existing.Count -gt 0) {
-              ($existing.GetEnumerator() | Sort-Object Name -Descending | Select-Object -First 5 |
-                ForEach-Object { '{0}={1}' -f $_.Key, $_.Value }) -join ', '
-            } else { '(no versions on CCR)' }
+            $statusSummary = ($statuses.GetEnumerator() | ForEach-Object {
+              '{0}={1}' -f $_.Key, ($_.Value ?? 'NotPushed')
+            }) -join ', '
             Write-Host "$pkg : $statusSummary"
 
-            $blocking = $existing.GetEnumerator() | Where-Object { $_.Value -in @('Submitted', 'Pending') }
-            if ($blocking) {
-              Write-Host "::notice::$pkg : pending submission(s) — $($blocking.Key -join ', ') — skipping this cycle"
-              continue
-            }
-            $rejected = $existing.GetEnumerator() | Where-Object { $_.Value -eq 'Rejected' }
-            if ($rejected) {
-              Write-Host "::error::$pkg : REJECTED submission(s) — $($rejected.Key -join ', ') — manual intervention needed"
-              continue
+            # Find highest target already pushed (any non-null status).
+            $pushedTargets = $targets | Where-Object { $null -ne $statuses[$_] }
+            $highestPushed = if ($pushedTargets) { $pushedTargets | Select-Object -Last 1 } else { $null }
+
+            if ($highestPushed) {
+              $latestStatus = $statuses[$highestPushed]
+              if ($latestStatus -in @('Pending', 'Unknown')) {
+                Write-Host "::notice::$pkg : highest pushed version $highestPushed is $latestStatus — skipping this cycle"
+                continue
+              }
+              if ($latestStatus -eq 'Rejected') {
+                Write-Host "::error::$pkg : highest pushed version $highestPushed was Rejected — manual intervention needed"
+                continue
+              }
+              # Approved → fall through to find next missing
             }
 
-            $next = $targets | Where-Object { -not $existing.ContainsKey($_) } | Select-Object -First 1
+            $next = $targets | Where-Object { $null -eq $statuses[$_] } | Select-Object -First 1
             if ($next) {
               Write-Host "::notice::$pkg : queueing push for version $next"
               $plan += [pscustomobject]@{ package = $pkg; version = $next }


### PR DESCRIPTION
## Summary

Fixes the false-positive in the backfill plan job that queued 8.19.14 for all 5 sibling Beats again on the dry-run after the initial push, even though those versions were already Submitted/Pending.

## Root cause

CCR's OData feed returns inconsistent statuses across query paths during moderation. For the same `Id+Version` (e.g. filebeat-oss 8.19.14):

- Direct-key endpoint `Packages(Id='...',Version='...')` → `PackageStatus=Approved, IsLatestVersion=true`
- Filter endpoint `?$filter=Id eq '...' and Version eq '...'` → `PackageStatus=Submitted, IsLatestVersion=false`

The previous plan job used a listing query (`?$filter=Id eq '...' &$orderby=Version desc`), which has its own index lag — just-submitted versions don't appear immediately. So the plan didn't see 8.19.14 in `$existing`, didn't trigger the pending-skip, and queued 8.19.14 again.

## Fix

Per-target direct-key lookup. For each version in `backfill.json`, query both endpoints and combine results conservatively:

| Direct status | Filter status | Combined |
|---|---|---|
| 404 | 404 | `null` (eligible to push) |
| any pending | * | `Pending` (skip) |
| * | any pending | `Pending` (skip) |
| any rejected | * | `Rejected` (error) |
| * | any rejected | `Rejected` (error) |
| Approved | Approved | `Approved` (advance) |
| else | else | `Unknown` (skip) |

Both endpoints must agree on `Approved` before the plan considers a version "really published" and advances to the next.

## Cost

Up to 2N HTTP GETs per package per plan run (N = backfill.json target count). For 6 Beats × 5 versions = 60 cheap GETs against community.chocolatey.org per cron tick. Negligible.

## Test plan

- [ ] Merge
- [ ] Dispatch with `dry_run=true`. Expected output:
  - `auditbeat-oss : 8.19.14=NotPushed, 9.3.0=NotPushed, ... → queueing 8.19.14`
  - `filebeat-oss : 8.19.14=Pending, 9.3.0=NotPushed, ... → highest pushed 8.19.14 is Pending — skipping`
  - Same for heartbeat-oss / metricbeat-oss / packetbeat-oss / winlogbeat-oss
- [ ] Re-dispatch with `dry_run=false`. Only auditbeat-oss should actually push.