### PR TITLE
backfill: trust the $filter endpoint; add force re-publish input

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -66,20 +66,38 @@ jobs:
               continue
             }
 
-            # CCR's OData feed returns inconsistent statuses across query paths
-            # during moderation: the direct-key endpoint may show Approved while
-            # the $filter endpoint still shows Submitted/Pending for the same
-            # Id+Version. We query BOTH and take the more conservative status —
-            # if either says Pending, we wait. This matches the user-facing
-            # behaviour where a package isn't fully published until both indices
-            # agree it is Approved.
-            function Get-CcrStatus($url) {
+            # CCR has multiple OData endpoints with INCONSISTENT data:
+            # - The direct-key endpoint Packages(Id=...,Version=...) returns
+            #   stale "Approved/IsApproved=true" data for packages that are
+            #   still in the moderation queue.
+            # - The $filter endpoint correctly reflects moderation state
+            #   (Submitted/IsApproved=false/Published=1900-01-01) for pending
+            #   versions, and (Approved/IsApproved=true/Published=<real date>)
+            #   for fully-published ones.
+            # The public package page at /packages/<id>/<version> agrees with
+            # the $filter endpoint, so we treat $filter as authoritative.
+            #
+            # A version is considered "fully approved and published" only when:
+            #   PackageStatus = Approved
+            #   AND IsApproved = true
+            #   AND Published date is not the 1900-01-01 placeholder
+            function Get-CcrApprovalState($pkg, $version) {
+              $url = "https://community.chocolatey.org/api/v2/Packages?`$filter=Id eq '$pkg' and Version eq '$version'"
               try {
                 $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -UserAgent 'mkopnsrc-backfill/1.0'
-                $m = [regex]::Match($resp.Content, '<d:PackageStatus[^>]*>([^<]+)</d:PackageStatus>')
-                if ($m.Success) { return $m.Groups[1].Value.Trim() }
-                if ($resp.Content -match '<entry>') { return 'Unknown' }
-                return $null
+                if ($resp.Content -notmatch '<entry>') { return $null }   # 404-equivalent: not on CCR
+
+                $statusMatch    = [regex]::Match($resp.Content, '<d:PackageStatus[^>]*>([^<]+)</d:PackageStatus>')
+                $approvedMatch  = [regex]::Match($resp.Content, '<d:IsApproved[^>]*>([^<]+)</d:IsApproved>')
+                $publishedMatch = [regex]::Match($resp.Content, '<d:Published[^>]*>([^<]+)</d:Published>')
+
+                $status      = if ($statusMatch.Success)    { $statusMatch.Groups[1].Value.Trim() }    else { 'Unknown' }
+                $isApproved  = $approvedMatch.Success -and $approvedMatch.Groups[1].Value.Trim() -eq 'true'
+                $isPublished = $publishedMatch.Success -and $publishedMatch.Groups[1].Value.Trim() -notmatch '^1900-'
+
+                if ($status -eq 'Rejected') { return 'Rejected' }
+                if ($status -eq 'Approved' -and $isApproved -and $isPublished) { return 'Approved' }
+                return 'Pending'
               } catch {
                 if ($_.Exception.Response.StatusCode.value__ -eq 404 -or $_.Exception.Message -match '404') {
                   return $null
@@ -90,22 +108,12 @@ jobs:
 
             $statuses = [ordered]@{}
             foreach ($v in $targets) {
-              $directUrl = "https://community.chocolatey.org/api/v2/Packages(Id='$pkg',Version='$v')"
-              $filterUrl = "https://community.chocolatey.org/api/v2/Packages?`$filter=Id eq '$pkg' and Version eq '$v'"
               try {
-                $direct = Get-CcrStatus $directUrl
-                $filter = Get-CcrStatus $filterUrl
+                $statuses[$v] = Get-CcrApprovalState $pkg $v
               } catch {
-                Write-Host "::warning::$pkg : CCR check for $v failed ($_); treating as unknown"
+                Write-Host "::warning::$pkg : CCR check for $v failed ($_); treating as Unknown"
                 $statuses[$v] = 'Unknown'
-                continue
               }
-              # Combine: most conservative wins
-              $statuses[$v] = if ($direct -eq $null -and $filter -eq $null) { $null }
-                              elseif ($direct -in @('Submitted','Pending') -or $filter -in @('Submitted','Pending')) { 'Pending' }
-                              elseif ($direct -eq 'Rejected' -or $filter -eq 'Rejected') { 'Rejected' }
-                              elseif ($direct -eq 'Approved' -and $filter -eq 'Approved') { 'Approved' }
-                              else { 'Unknown' }
             }
 
             $statusSummary = ($statuses.GetEnumerator() | ForEach-Object {

--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -31,6 +31,11 @@ on:
         type: string
         required: false
         default: ''
+      force:
+        description: 'Force re-publish: sets $global:au_Force=true so AU bumps the version to chocolatey fix notation (X.Y.Z.YYYYMMDD) and re-pushes. Use only when a previously-pushed version needs to be republished with corrected content.'
+        type: boolean
+        required: false
+        default: false
 
   workflow_call:
     inputs:
@@ -47,6 +52,10 @@ on:
         required: false
         type: string
         default: ''
+      force:
+        required: false
+        type: boolean
+        default: false
     secrets:
       CHOCO_API_KEY:
         required: false
@@ -61,6 +70,7 @@ jobs:
     env:
       PACKAGE: ${{ inputs.package }}
       FORCE_VERSION: ${{ inputs.force_version }}
+      AU_FORCE: ${{ inputs.force }}
 
     steps:
       - uses: actions/checkout@v5
@@ -71,6 +81,7 @@ jobs:
           if (-not (Test-Path $dir)) { throw "Package directory not found: $dir" }
           Write-Host "Building package from $dir"
           if ($env:FORCE_VERSION) { Write-Host "Forcing version: $env:FORCE_VERSION" }
+          if ($env:AU_FORCE -eq 'true') { Write-Host "Force-republish ENABLED — AU will use chocolatey fix notation (X.Y.Z.YYYYMMDD)" }
 
       - name: Install AU module to PSModulePath
         run: |
@@ -83,6 +94,10 @@ jobs:
           if ($env:FORCE_VERSION) {
             $global:au_Version = $env:FORCE_VERSION
             Write-Host "Forcing au_Version: $global:au_Version"
+          }
+          if ($env:AU_FORCE -eq 'true') {
+            $global:au_Force = $true
+            Write-Host "Forcing au_Force: \$true (will bump to fix notation if version already on CCR)"
           }
           ./update.ps1
 


### PR DESCRIPTION
## Summary

Two fixes:

1. **Plan logic v2** — PR #21 was based on a wrong premise. Switching to filter-only with stricter checks.
2. **`force` input** — adds a manual escape hatch to re-publish a same-logical-version with corrected content (uses chocolatey fix notation `X.Y.Z.YYYYMMDD`).

## Plan logic v2 — what was wrong

PR #21 used a dual-query "conservative" combine, taking the most-pending status across endpoints. But empirically, CCR's two endpoints don't just disagree *during* transitions — the **direct-key endpoint** `Packages(Id=...,Version=...)` returns **persistently stale** `Approved/IsApproved=true/Published=<created>` data for packages that are still pending moderation.

Verified against the live state of `filebeat-oss 8.19.14`:

| Source | Result |
|---|---|
| Direct-key OData | `PackageStatus=Approved, IsApproved=true, Published=2026-04-27T22:24:41.933` |
| Filter OData | `PackageStatus=Submitted, IsApproved=false, Published=1900-01-01T00:00:00` |
| Public web page `/packages/filebeat-oss/8.19.14` | Shows "Pending" 5 times |

The `$filter` endpoint and the public web page agree. So we treat `$filter` as authoritative.

## New plan logic

For each backfill target version, query the `$filter` endpoint and require **all three** of:

- `PackageStatus = Approved`
- `IsApproved = true`
- `Published` date is not the `1900-01-01T00:00:00` placeholder

before treating the version as "fully approved and published". Anything else → `Pending` (skip). Explicit `Rejected` → error.

## `force` input

Adds a `force` boolean to `package-build-test.yml` (both `workflow_dispatch` and `workflow_call`). When `true`, the workflow sets `\$global:au_Force = \$true` before running `update.ps1`. Per AU's documented behaviour:

> If NuspecVersion is the same as the RemoteVersion, the version will change to chocolatey fix notation (X.Y.Z.YYYYMMDD).

Use case: a previously-pushed version was built with broken content (e.g. wrong checksum cached, or the previous plan-logic bug republished an identical artifact). Manually dispatch `package-build-test.yml` with `force_version=<that version>` and `force=true` — AU will bump to fix notation and re-push.

`backfill.yml` does **not** pass `force`. The cron loop never auto-republishes; force is a manual-only escape hatch.

## Test plan

- [ ] Merge
- [ ] Dispatch `backfill.yml` with `dry_run=true`. Expected output:
  - `auditbeat-oss : 8.19.14=NotPushed, ... → queueing 8.19.14`
  - `filebeat-oss : 8.19.14=Pending, ... → highest pushed 8.19.14 is Pending — skipping`
  - Same `Pending → skipping` for the other 4 sibling Beats
- [ ] Re-dispatch with `dry_run=false` to actually push auditbeat-oss 8.19.14