### PR TITLE
backfill: auto-open aggregated PR with bumped files after each cycle

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -159,3 +159,88 @@ jobs:
       publish: true
       force_version: ${{ matrix.target.version }}
     secrets: inherit
+
+  commit-pr:
+    name: Open aggregated PR with bumped package files
+    needs: push
+    if: ${{ always() && needs.plan.outputs.has_work == 'True' && inputs.dry_run != true }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all bumped-package artifacts from this run
+        uses: actions/download-artifact@v5
+        with:
+          path: /tmp/pkgfiles
+          pattern: pkgfiles-*
+        continue-on-error: true
+
+      - name: Apply artifacts to working tree
+        shell: pwsh
+        run: |
+          if (-not (Test-Path '/tmp/pkgfiles')) {
+            Write-Host "No pkgfiles-* artifacts present — nothing to commit"
+            "APPLIED_COUNT=0" >> $env:GITHUB_ENV
+            return
+          }
+          $applied = @()
+          foreach ($dir in (Get-ChildItem '/tmp/pkgfiles' -Directory)) {
+            if ($dir.Name -match '^pkgfiles-(.+?)-([\d.]+)$') {
+              $pkg = $matches[1]
+              $version = $matches[2]
+              $dst = "automatic/$pkg"
+              if (-not (Test-Path $dst)) {
+                Write-Host "::warning::Destination $dst does not exist; skipping $($dir.Name)"
+                continue
+              }
+              Write-Host "Applying $($dir.Name) -> $dst"
+              Copy-Item -Recurse -Force "$($dir.FullName)/*" "$dst/"
+              $applied += "$pkg=$version"
+            } else {
+              Write-Host "::warning::Unexpected artifact name: $($dir.Name)"
+            }
+          }
+          "APPLIED_COUNT=$($applied.Count)" >> $env:GITHUB_ENV
+          "APPLIED_LIST=$($applied -join '|')" >> $env:GITHUB_ENV
+          Write-Host "Applied: $($applied -join ', ')"
+
+      - name: Commit and open PR
+        if: env.APPLIED_COUNT != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          DATE=$(date -u +%Y-%m-%d-%H%M)
+          BRANCH="bot/backfill-${DATE}"
+          git checkout -b "$BRANCH"
+          git add automatic/
+          if git diff --cached --quiet; then
+            echo "No changes to commit (artifacts applied but no diff vs master)"
+            exit 0
+          fi
+          # Build PR body bullet list from APPLIED_LIST (pipe-separated pkg=version)
+          BODY_LINES=""
+          IFS='|' read -ra ITEMS <<< "$APPLIED_LIST"
+          for item in "${ITEMS[@]}"; do
+            BODY_LINES="${BODY_LINES}- \`${item%%=*}\` -> \`${item##*=}\`"$'\n'
+          done
+          TITLE="automated: backfill ${DATE} (${APPLIED_COUNT} packages)"
+          BODY="The packages below were pushed to chocolatey.org during this backfill cycle. This PR keeps the repo files in sync with what was published.
+
+          Bumped:
+          ${BODY_LINES}
+          Each push was install-tested on a fresh \`windows-2022\` runner and submitted to chocolatey.org's moderation queue. Merging this PR has no further publishing side-effect.
+          "
+          git commit -m "${TITLE}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --assignee mkopnsrc \
+            --title "${TITLE}" \
+            --body "${BODY}"

--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -151,3 +151,11 @@ jobs:
           name: ${{ inputs.package }}-${{ env.PACKAGE_VERSION }}-nupkg
           path: ${{ runner.temp }}/*.nupkg
           retention-days: 14
+
+      - name: Upload modified package files (consumed by backfill commit-pr)
+        if: ${{ inputs.publish && success() && env.PACKAGE_VERSION != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: pkgfiles-${{ inputs.package }}-${{ env.PACKAGE_VERSION }}
+          path: automatic/${{ inputs.package }}/
+          retention-days: 1


### PR DESCRIPTION
## Summary

Closes the loop on the "git package files don't update along the way" issue. Until now the workflow pushed bumped versions to chocolatey.org but the `nuspec` / `chocolateyInstall.ps1` / `*.json` files in master stayed at the pre-backfill baseline.

After this PR, every cron tick that successfully pushes one or more packages also opens a single aggregated PR (assigned to `mkopnsrc`) with the bumped files.

## How it works

1. **`package-build-test.yml`** (existing reusable workflow): adds a new step that uploads the post-update package directory as `pkgfiles-<pkg>-<version>` artifact, only on successful publish, 1-day retention.

2. **`backfill.yml`** (new `commit-pr` job): runs after the matrix `push` completes. Downloads all `pkgfiles-*` artifacts from the same run, copies them onto a fresh master checkout, commits one commit, pushes to `bot/backfill-<date-time>`, opens a PR assigned to `mkopnsrc` with a per-package bullet list.

## Behaviour examples

| Scenario | Result |
|---|---|
| Cron tick, all packages skipped (Pending/caught-up) | No push jobs run → no artifacts → commit-pr exits without opening a PR |
| Cron tick pushes 3 packages successfully | One PR titled `automated: backfill 2026-04-28-0815 (3 packages)` |
| Cron tick pushes 1, fails 1 | PR opened with the 1 successful bump only |
| Manual dispatch of `package-build-test.yml` directly | Artifact uploaded but no commit-pr job consumes it → expires after 1 day, harmless |

## Why aggregated PR instead of direct push to master

We considered direct push (Path 1) but the Ruleset bypass picker on free public repos doesn't expose `github-actions[bot]` as a bypassable actor — only "Repository admin" role-based bypass, which the workflow's `GITHUB_TOKEN` doesn't satisfy. Aggregated PR avoids needing a PAT secret and keeps the audit trail at one merge per cycle (max 4/day given 6h cron).

## Test plan

- [ ] Merge
- [ ] Wait for next 6h cron tick (or manual dispatch with `dry_run=false`)
- [ ] Verify a `bot/backfill-<date>` branch was created and a PR opened, assigned to `mkopnsrc`
- [ ] Inspect PR diff: should contain bumped `nuspec` version + new URL/checksum in `chocolateyInstall.ps1` for each pushed package
- [ ] Admin-merge the PR
- [ ] Verify next cron sees fresh baseline (nuspec versions match what's on chocolatey.org)