### PR TITLE
workflow: add skip_install_test input for heavy installers

### DIFF
--- a/.github/workflows/package-build-test.yml
+++ b/.github/workflows/package-build-test.yml
@@ -36,6 +36,11 @@ on:
         type: boolean
         required: false
         default: false
+      skip_install_test:
+        description: 'Skip the local install / verify / uninstall steps. Use for packages whose installer takes longer than the workflow timeout (e.g. refinitiv-workspace). Pack and push still happen normally; chocolatey-side moderation will validate the install.'
+        type: boolean
+        required: false
+        default: false
 
   workflow_call:
     inputs:
@@ -53,6 +58,10 @@ on:
         type: string
         default: ''
       force:
+        required: false
+        type: boolean
+        default: false
+      skip_install_test:
         required: false
         type: boolean
         default: false
@@ -114,12 +123,14 @@ jobs:
           }
 
       - name: Install package from local source
+        if: ${{ !inputs.skip_install_test }}
         run: |
           choco install $env:PACKAGE `
             --source "$env:RUNNER_TEMP;https://community.chocolatey.org/api/v2/" `
             --confirm --no-progress
 
       - name: Verify install via chocolatey local list
+        if: ${{ !inputs.skip_install_test }}
         run: |
           # chocolatey's own list is the authoritative "did the package install"
           # check. Registry lookup by package id is unreliable — installers
@@ -134,6 +145,7 @@ jobs:
           Write-Host $listing
 
       - name: Uninstall
+        if: ${{ !inputs.skip_install_test }}
         run: choco uninstall $env:PACKAGE --confirm --no-progress
 
       - name: Push to chocolatey.org community feed


### PR DESCRIPTION
## Summary

Adds a `skip_install_test` boolean input to `package-build-test.yml` (both `workflow_dispatch` and `workflow_call`). When `true`, the install / verify / uninstall steps are skipped — pack and push still run normally.

## Why

Refinitiv Workspace's installer takes longer than the 30-minute workflow timeout (large financial-data desktop app with bundled charts, news feeds, market connectors). The `refinitive-workspace` 1.26.602 dry-run via [run 25036786050](https://github.com/mkopnsrc/chocolatey-packages/actions/runs/25036786050) hit the timeout at "Install package from local source" after 29 minutes — the install never completed within the workflow's budget.

## Behaviour matrix

| `skip_install_test` | `publish` | What runs |
|---|---|---|
| false (default) | false | Pack → install → verify → uninstall |
| false | true | Pack → install → verify → uninstall → push |
| **true** | false | Pack only (just to validate it builds) |
| **true** | true | Pack → push (skip local install) |

## Trade-off

When `skip_install_test=true`, we lose the "does this actually install on a fresh Windows runner" smoke check. Chocolatey's moderation queue does its own install validation on a moderator-side environment, so it's not a complete loss — but local catches issues earlier.

Use `skip_install_test=true` only when:
1. The package's installer legitimately takes >25 min (heavy enterprise apps), AND
2. The package code has been validated by other means (e.g. previous version of same id was already approved on CCR)

## Test plan

- [ ] Merge
- [ ] Re-dispatch `refinitiv-workspace` with `skip_install_test=true` + `publish=true`
- [ ] Verify pack → push completes within ~3-5 minutes
- [ ] Watch chocolatey moderation for `refinitiv-workspace 1.26.602`