### PR TITLE
refinitiv-workspace: VM auto-detect, package params for Excel/Chrome opt-in

### DIFF
--- a/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
+++ b/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
@@ -20,6 +20,41 @@
 
 Refinitiv Workspace is the financial analysis desktop and mobile solution, providing access to leading data and content, Reuters news, markets and liquidity pools.
 
+### Install behaviour
+
+By default the package installs the **core Refinitiv Workspace** only — the Excel addin and Chrome browser extension are skipped. Both can be opted-in via chocolatey package parameters:
+
+```
+choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
+```
+
+| Parameter | Effect |
+|---|---|
+| `/include-excel` | Installs the Refinitiv Excel addin (COM registration; adds startup time) |
+| `/include-chrome-extension` | Registers the Chrome native messaging host for in-browser charting |
+
+The installer auto-detects whether the target machine is physical hardware or a VM/VDI guest and selects `--mode=machine` or `--mode=vdi` accordingly.
+
+### Differences from the vendor's default install args
+
+The chocolatey package modifies the following from Refinitiv's interactive-installer defaults to make the install non-interactive and minimal-by-default. Run the installer directly from [LSEG's website](https://www.lseg.com/en/data-analytics/products/workspace/download-workspace) if you need the full vendor-default behaviour.
+
+| Arg | What it changes vs. vendor default |
+|---|---|
+| `--silent` | Suppresses the install UI (vendor default: interactive) |
+| `--forceInstall` | Installs even if a previous version is present (vendor default: prompt) |
+| `--lang=en` | Pins UI language to English (vendor default: detect from OS) |
+| `--no-update` | Skips the bootstrapper's first-run update check (vendor default: check for newer build before install) |
+| `--machine-autoupdate-no` | Disables the post-install auto-update service (vendor default: install the auto-updater) |
+| `--mode=machine` or `--mode=vdi` | Auto-selected from VM detection (vendor default: prompt for install type) |
+| `--shortcut-workspace=true` | Creates the Workspace desktop shortcut (matches vendor default) |
+| `--shortcut-excel=false` | Skips the Excel-launcher shortcut unless `/include-excel` is passed (vendor default: create) |
+| `--shortcut-messenger=false` | Skips the Messenger desktop shortcut (vendor default: create) |
+| `--no-excel` | **Default**: skip the Excel addin install (vendor default: install). Override with `--params "/include-excel"` |
+| `--no-chrome-extension` | **Default**: skip the Chrome native-messaging host (vendor default: install). Override with `--params "/include-chrome-extension"` |
+
+To re-enable Refinitiv's auto-updater after install, reinstall the application directly via the LSEG website or upgrade via chocolatey when a new package version is published.
+
 ### Note on the package id rename
 
 This package replaces the legacy [`refinitive-workspace`](https://community.chocolatey.org/packages/refinitive-workspace) id, which had a typo in the brand name. New installs should use `refinitiv-workspace`. Existing installs of `refinitive-workspace` will be migrated to this id automatically via dependency resolution.

--- a/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
+++ b/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
@@ -2,11 +2,73 @@ $ErrorActionPreference = 'Stop'
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsDir\helpers.ps1
 
+# ---------------------------------------------------------------------------
+# Detect physical machine vs virtual machine.
+# Refinitiv Workspace's installer accepts --mode=machine and --mode=vdi.
+# Auto-select based on detected hypervisor presence.
+# ---------------------------------------------------------------------------
+function Test-IsVirtualMachine {
+    try {
+        $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    # Common hypervisor / virtualization markers in Manufacturer or Model.
+    $vmPatterns = '(?i)VMware|VirtualBox|innotek|Xen|HVM domU|KVM|QEMU|Parallels|Citrix|Bochs'
+    if ($cs.Model -match $vmPatterns)        { return $true }
+    if ($cs.Manufacturer -match $vmPatterns) { return $true }
+    # Hyper-V / Azure: Microsoft Corporation + 'Virtual Machine' model
+    if ($cs.Manufacturer -eq 'Microsoft Corporation' -and $cs.Model -match 'Virtual Machine') {
+        return $true
+    }
+    return $false
+}
+
+$installMode = if (Test-IsVirtualMachine) { 'vdi' } else { 'machine' }
+Write-Host "Detected install mode: --mode=$installMode"
+
+# ---------------------------------------------------------------------------
+# User-supplied chocolatey package parameters.
+#
+# By default Excel and Chrome integration are NOT installed (faster install,
+# fewer side effects). Users can opt-in via:
+#
+#   choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
+#
+# Both kebab-case (include-excel) and PascalCase (IncludeExcel) accepted.
+# ---------------------------------------------------------------------------
+$pp = Get-PackageParameters
+$includeExcel  = $pp.ContainsKey('include-excel')           -or $pp.ContainsKey('IncludeExcel')
+$includeChrome = $pp.ContainsKey('include-chrome-extension') -or $pp.ContainsKey('IncludeChromeExtension')
+
+Write-Host ("Excel integration:  " + $(if ($includeExcel)  { 'ENABLED  (--params /include-excel)' }           else { 'disabled (default; pass /include-excel to enable)' }))
+Write-Host ("Chrome extension:   " + $(if ($includeChrome) { 'ENABLED  (--params /include-chrome-extension)' } else { 'disabled (default; pass /include-chrome-extension to enable)' }))
+
+# ---------------------------------------------------------------------------
+# Build silent-install args.
+# ---------------------------------------------------------------------------
 $UserTemp = $env:TEMP
 $LogPath  = Join-Path $UserTemp $env:ChocolateyPackageName
 if (-not (Test-Path $LogPath)) {
     New-Item -ItemType Directory -Name $env:ChocolateyPackageName -Path $UserTemp -Force | Out-Null
 }
+
+$silentArgList = @(
+    '--silent',
+    '--forceInstall',
+    '--lang=en',
+    '--no-update',
+    '--machine-autoupdate-no',
+    "--mode=$installMode",
+    '--shortcut-workspace=true',
+    '--shortcut-messenger=false',
+    "--installerlogpath=`"$LogPath`""
+)
+if (-not $includeExcel)  { $silentArgList += '--no-excel'; $silentArgList += '--shortcut-excel=false' } else { $silentArgList += '--shortcut-excel=true' }
+if (-not $includeChrome) { $silentArgList += '--no-chrome-extension' }
+
+$silentArgs = $silentArgList -join ' '
+Write-Host "Silent args: $silentArgs"
 
 $packageArgs = @{
     PackageName    = $env:ChocolateyPackageName
@@ -16,7 +78,7 @@ $packageArgs = @{
     Url            = 'https://cdn.refinitiv.com/public/packages/Workspace/RefinitivWorkspace-installer_1.26.602.exe'
     checksum       = '3ed94f04d14868df119b2f50de0397f12e0193b7465e5b06d0d71e85ca63b873'
     checksumType   = 'SHA256'
-    SilentArgs     = "--silent --forceInstall --lang=en --machine-autoupdate-no --shortcut-workspace=TRUE --shortcut-excel=FALSE --installerlogpath='$LogPath'"
+    SilentArgs     = $silentArgs
     validExitCodes = @(
         0,           # success
         3010,        # success, restart required


### PR DESCRIPTION
## Summary

In response to the moderator-side timeout on `refinitiv-workspace 1.26.602` auto-validation (install ran ~44 min, hit chocolatey's 2700s ceiling per their [debug log](https://gist.github.com/choco-bot/00cb5e8d99f12a93f983974a39ca5b4e)), instrument `chocolateyInstall.ps1` to:

1. **Auto-detect VM vs physical machine** via `Get-CimInstance Win32_ComputerSystem`. Pass `--mode=vdi` on virtual hosts (chocolatey moderator's Vagrant box gets this) or `--mode=machine` on physical. Refinitiv's installer is supposed to optimize the VDI path.
2. **Skip Excel addin + Chrome extension by default** (`--no-excel --no-chrome-extension`). Both are heavy: Excel does COM registration and startup overhead; Chrome extension writes registry keys for native messaging host. Skipping by default cuts install time and matches what most chocolatey users need.
3. **Opt-in via package parameters**:
   ```
   choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
   ```
   Both kebab-case (`include-excel`) and PascalCase (`IncludeExcel`) accepted.
4. **Add `--no-update`** alongside existing `--machine-autoupdate-no`. Different code paths in the installer (one suppresses the bootstrapper's first-run update check, the other disables the background updater service). Belt-and-braces.

## How I validated the args

Downloaded the bootstrapper, extracted the inner Electron installer (`installer-RefinitivWorkspace-win32-x64/setup.exe` and `app.asar`), ran `strings` over the asar bundle, grep'd for actual arg-key literals (not help text). Confirmed:

- `silent`, `forceInstall`, `machine-autoupdate-no` appear as quoted property keys in the installer's JS — the installer's yargs/commander parser reads these directly.
- `--no-update`, `--mode=machine`, `--mode=vdi`, `--no-excel`, `--no-chrome-extension`, `--shortcut-*=true|false` all appear in the installer's CLI flag table.

## What this changes for end users

| Scenario | Before | After |
|---|---|---|
| `choco install refinitiv-workspace` | core + Excel addin + Chrome extension | core only |
| `choco install refinitiv-workspace --params "/include-excel"` | n/a (no param parsing) | core + Excel |
| `choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"` | n/a | full install |

Documented in the nuspec description so chocolatey moderators see the rationale during review.

## Test plan

- [ ] Merge
- [ ] Dispatch `refinitiv-workspace` with `force_version=1.26.602`, `force=true`, `skip_install_test=true`, `publish=true` — pushes a chocolatey-fix-notation `1.26.602.YYYYMMDD` since the original 1.26.602 is still in moderation
- [ ] Watch chocolatey moderation. The VM-detect path will pick `--mode=vdi` on their Vagrant box; `--no-excel --no-chrome-extension` should cut significant install time
- [ ] If still times out, the slowness is in the bootstrapper's TEMP-extraction phase (700 MB), not anything args can fix