### PR TITLE
add crossplane-cli and atmos chocolatey packages

### DIFF
--- a/automatic/atmos/atmos.nuspec
+++ b/automatic/atmos/atmos.nuspec
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+    <metadata>
+        <id>atmos</id>
+        <version>1.216.0</version>
+        <title>Atmos</title>
+        <authors>Cloud Posse</authors>
+        <owners>opnsrc.dev</owners>
+        <projectUrl>https://atmos.tools</projectUrl>
+        <iconUrl>https://rawcdn.githack.com/cloudposse/atmos/main/website/static/img/atmos-logo.svg</iconUrl>
+        <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/atmos</packageSourceUrl>
+        <licenseUrl>https://github.com/cloudposse/atmos/blob/main/LICENSE</licenseUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <releaseNotes>https://github.com/cloudposse/atmos/releases</releaseNotes>
+        <docsUrl>https://atmos.tools</docsUrl>
+        <bugTrackerUrl>https://github.com/cloudposse/atmos/issues</bugTrackerUrl>
+        <language>en-US</language>
+        <tags>atmos cloudposse terraform opentofu helmfile devops platform-engineering iac infrastructure</tags>
+        <description>
+## Atmos
+
+[Atmos](https://atmos.tools) is a workflow tool for DevOps that orchestrates Terraform, OpenTofu, Helmfile, and other tools across multi-account, multi-region, multi-environment cloud architectures. From [Cloud Posse](https://cloudposse.com).
+
+Key features:
+
+* **Configuration as code** — YAML stack files describe your environments, accounts, and component compositions; Atmos generates the Terraform/Helmfile invocations.
+* **DRY infrastructure** — share component definitions across stacks; override per-stack settings without copying entire modules.
+* **Multi-tool orchestration** — run Terraform, OpenTofu, Helmfile, and custom commands through a unified `atmos` CLI.
+* **Workflows** — chain commands across stacks and components into reusable named workflows.
+* **Validation** — validate components and stacks before they hit `apply`.
+
+This package installs the `atmos` binary into chocolatey's `tools` directory, where it's automatically added to `PATH` via chocolatey's shim.
+
+### Versioning
+
+Tracks the upstream `cloudposse/atmos` GitHub releases. Each new release is auto-detected by the maintainer's CI.
+        </description>
+        <summary>Atmos by Cloud Posse — workflow tool that orchestrates Terraform, OpenTofu, and Helmfile across multi-account, multi-region cloud architectures.</summary>
+    </metadata>
+    <files>
+        <file src="tools\**" target="tools" />
+    </files>
+</package>

--- a/automatic/atmos/tools/chocolateyInstall.ps1
+++ b/automatic/atmos/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+# atmos.exe is a single-binary CLI. Download into the package's tools directory;
+# chocolatey auto-shims any .exe in tools/ for PATH resolution.
+$packageArgs = @{
+    packageName  = $env:ChocolateyPackageName
+    fileFullPath = Join-Path $toolsDir 'atmos.exe'
+    url          = 'https://github.com/cloudposse/atmos/releases/download/v1.216.0/atmos_1.216.0_windows_amd64.exe'
+    checksum     = '01f55a1522044ad6a50ac6038c9889c4f2ae49db847d2df3a54ffe84485fe43e'
+    checksumType = 'SHA256'
+}
+Get-ChocolateyWebFile @packageArgs

--- a/automatic/atmos/update.ps1
+++ b/automatic/atmos/update.ps1
@@ -1,0 +1,37 @@
+Import-Module au
+
+$githubRepo   = 'cloudposse/atmos'
+$ChecksumType = 'SHA256'
+
+function global:au_BeforeUpdate {
+    $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32
+}
+
+function global:au_GetLatest {
+    if ($global:au_Version) {
+        $version = $global:au_Version
+    } else {
+        $api = Invoke-RestMethod -Uri "https://api.github.com/repos/$githubRepo/releases/latest" -UseBasicParsing
+        $version = $api.tag_name -replace '^v', ''
+    }
+
+    $url = "https://github.com/$githubRepo/releases/download/v$version/atmos_${version}_windows_amd64.exe"
+
+    @{
+        URL32          = $url
+        Version        = $version
+        ChecksumType32 = $ChecksumType
+    }
+}
+
+function global:au_SearchReplace {
+    @{
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(?i)(^\s*url\s*=\s*)('.*')"          = "`$1'$($Latest.URL32)'"
+            "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+        }
+    }
+}
+
+update -ChecksumFor none

--- a/automatic/crossplane-cli/crossplane-cli.nuspec
+++ b/automatic/crossplane-cli/crossplane-cli.nuspec
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+    <metadata>
+        <id>crossplane-cli</id>
+        <version>2.2.1</version>
+        <title>Crossplane CLI (crank)</title>
+        <authors>The Crossplane Authors</authors>
+        <owners>opnsrc.dev</owners>
+        <projectUrl>https://crossplane.io</projectUrl>
+        <iconUrl>https://rawcdn.githack.com/cncf/artwork/master/projects/crossplane/icon/color/crossplane-icon-color.svg</iconUrl>
+        <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/crossplane-cli</packageSourceUrl>
+        <licenseUrl>https://github.com/crossplane/crossplane/blob/main/LICENSE</licenseUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <releaseNotes>https://github.com/crossplane/crossplane/releases</releaseNotes>
+        <docsUrl>https://docs.crossplane.io/latest/cli/</docsUrl>
+        <bugTrackerUrl>https://github.com/crossplane/crossplane/issues</bugTrackerUrl>
+        <language>en-US</language>
+        <tags>crossplane crank cli kubernetes k8s cncf infrastructure platform-engineering iac</tags>
+        <description>
+## Crossplane CLI (`crank`)
+
+The Crossplane command-line interface — `crank` — is the official CLI for [Crossplane](https://crossplane.io), a CNCF project that turns any Kubernetes cluster into a control plane for cloud and on-prem infrastructure.
+
+`crank` lets platform engineers build, test, package, and ship Crossplane Configurations and Functions:
+
+* **Build & push** Configurations and Functions as OCI artifacts (`crank xpkg build`, `crank xpkg push`).
+* **Render** Compositions locally for fast iteration (`crank render`).
+* **Test** Compositions with `crank test render` and `crank test e2e`.
+* **Beta features** for new Crossplane v2 capabilities accessible via `crank beta`.
+
+This package installs the `crank` binary into chocolatey's `tools` directory, where it's automatically added to `PATH` via chocolatey's shim.
+
+### Versioning
+
+Tracks the upstream `crossplane/crossplane` GitHub releases (stable channel, `releases.crossplane.io/stable/v&lt;version&gt;/bin/windows_amd64/crank.exe`). Each new release is auto-detected by the maintainer's CI.
+        </description>
+        <summary>The Crossplane CLI (`crank`) — official command-line tool for building, pushing, rendering, and testing Crossplane Configurations and Functions.</summary>
+    </metadata>
+    <files>
+        <file src="tools\**" target="tools" />
+    </files>
+</package>

--- a/automatic/crossplane-cli/tools/chocolateyInstall.ps1
+++ b/automatic/crossplane-cli/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+# crank.exe is a single-binary CLI. Download into the package's tools directory;
+# chocolatey auto-shims any .exe in tools/ for PATH resolution.
+$packageArgs = @{
+    packageName  = $env:ChocolateyPackageName
+    fileFullPath = Join-Path $toolsDir 'crank.exe'
+    url          = 'https://releases.crossplane.io/stable/v2.2.1/bin/windows_amd64/crank.exe'
+    checksum     = 'dd33976f4f32f10792018d0964a8ee64b58e7f966d90947fa2e61bf7dd707da9'
+    checksumType = 'SHA256'
+}
+Get-ChocolateyWebFile @packageArgs

--- a/automatic/crossplane-cli/update.ps1
+++ b/automatic/crossplane-cli/update.ps1
@@ -1,0 +1,39 @@
+Import-Module au
+
+$githubRepo   = 'crossplane/crossplane'
+$ChecksumType = 'SHA256'
+
+function global:au_BeforeUpdate {
+    $Latest.Checksum32 = Get-RemoteChecksum $Latest.URL32 -Algorithm $Latest.ChecksumType32
+}
+
+function global:au_GetLatest {
+    if ($global:au_Version) {
+        $version = $global:au_Version
+    } else {
+        $api = Invoke-RestMethod -Uri "https://api.github.com/repos/$githubRepo/releases/latest" -UseBasicParsing
+        $version = $api.tag_name -replace '^v', ''
+    }
+
+    # Crossplane CLI ('crank') ships from releases.crossplane.io rather than
+    # GitHub release assets. The versioned URL pattern:
+    $url = "https://releases.crossplane.io/stable/v$version/bin/windows_amd64/crank.exe"
+
+    @{
+        URL32          = $url
+        Version        = $version
+        ChecksumType32 = $ChecksumType
+    }
+}
+
+function global:au_SearchReplace {
+    @{
+        ".\tools\chocolateyInstall.ps1" = @{
+            "(?i)(^\s*url\s*=\s*)('.*')"          = "`$1'$($Latest.URL32)'"
+            "(?i)(^\s*checksum\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum32)'"
+            "(?i)(^\s*checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+        }
+    }
+}
+
+update -ChecksumFor none


### PR DESCRIPTION
## Summary

Two new IT/sysadmin packages with no current chocolatey coverage. Both follow the repo's standard packaging pattern (`$global:au_Version`-aware `update.ps1`) but **no `backfill.json`** — they track upstream-latest only.

## What's new

| Package id | Source | Format | Latest |
|---|---|---|---|
| `crossplane-cli` | [releases.crossplane.io stable channel](https://releases.crossplane.io/) (binary), tag from [crossplane/crossplane](https://github.com/crossplane/crossplane/releases) | Single .exe (`crank.exe`) | 2.2.1 |
| `atmos` | [cloudposse/atmos](https://github.com/cloudposse/atmos/releases) | Single .exe | 1.216.0 |

Conflict check: both ids are unclaimed on community.chocolatey.org.

## Note: otelcol-contrib dropped

`otelcol-contrib` was originally part of this PR but was removed after discovering the existing [`opentelemetry-collector-contrib`](https://community.chocolatey.org/packages/opentelemetry-collector-contrib) chocolatey package (currently at v0.104.0, last updated 2024-07-04 by @droosma). Issue [droosma/opentelemetry-collector-contrib-chocolatey#3](https://github.com/droosma/opentelemetry-collector-contrib-chocolatey/issues/3) was opened offering to either submit PRs for new releases or join as co-maintainer. Waiting for that response before deciding whether to create a competing id.

## Per-package details

### `crossplane-cli` (`crank`)
- Official Crossplane CLI for building, pushing, rendering, and testing Configurations and Functions
- Single-binary: `tools/crank.exe` (chocolatey auto-shims)
- Apache 2.0
- URL pattern: `releases.crossplane.io/stable/v<version>/bin/windows_amd64/crank.exe`
- Tag queried from `crossplane/crossplane` GitHub API

### `atmos`
- Cloud Posse's workflow tool for Terraform/OpenTofu/Helmfile orchestration
- Single-binary: `tools/atmos.exe` (~209 MB Go binary)
- Apache 2.0

## Test plan

- [ ] Merge
- [ ] Dispatch dry runs (`publish=false`) for crossplane-cli and atmos
- [ ] On green, dispatch with `publish=true` to push to chocolatey moderation
- [ ] Brand-new ids → first-time id-name review (1–7 days)