### PR TITLE
crossplane-cli: escape ampersand in nuspec description (XML parse fix)

### DIFF
--- a/automatic/crossplane-cli/crossplane-cli.nuspec
+++ b/automatic/crossplane-cli/crossplane-cli.nuspec
@@ -23,7 +23,7 @@ The Crossplane command-line interface — `crank` — is the official CLI for [C
 
 `crank` lets platform engineers build, test, package, and ship Crossplane Configurations and Functions:
 
-* **Build & push** Configurations and Functions as OCI artifacts (`crank xpkg build`, `crank xpkg push`).
+* **Build and push** Configurations and Functions as OCI artifacts (`crank xpkg build`, `crank xpkg push`).
 * **Render** Compositions locally for fast iteration (`crank render`).
 * **Test** Compositions with `crank test render` and `crank test e2e`.
 * **Beta features** for new Crossplane v2 capabilities accessible via `crank beta`.


### PR DESCRIPTION
## Summary

Fix follow-up to PR #33. The dry-run for `crossplane-cli` failed at the `Run AU update.ps1` step with:

```
Update-Package: D:\a\chocolatey-packages\chocolatey-packages\automatic\crossplane-cli\update.ps1:39
Exception calling "Load" with "1" argument(s): "An error occurred while parsing EntityName. Line 26, position 12."
```

`crossplane-cli.nuspec` line 26 had `**Build & push**` — a raw ampersand inside an XML text node. AU's `update.ps1` loads the nuspec via `[xml]$nuspec = ...` before running `au_SearchReplace`, and bare ampersands break the XML parse.

Replaced with `**Build and push**` (simpler than entity-encoding to `&amp;`).

## Test plan

- [ ] Merge
- [ ] Re-dispatch `crossplane-cli` with `publish=false` (dry run)
- [ ] On green, dispatch with `publish=true`