### PR TITLE
refinitiv-workspace: drop bogus install args + add /install-mode and /client-sso params

### DIFF
--- a/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
+++ b/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
@@ -22,16 +22,17 @@ Refinitiv Workspace is the financial analysis desktop and mobile solution, provi
 
 ### Install behaviour
 
-By default the package installs the **core Refinitiv Workspace** only — the Excel addin and Chrome browser extension are skipped. Both can be opted-in via chocolatey package parameters:
+By default the package installs the **core Refinitiv Workspace** only — the Excel addin and Chrome browser extension are skipped. They (and the optional SSO endpoint) can be enabled via chocolatey package parameters:
 
 ```
-choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
+choco install refinitiv-workspace --params "/include-excel /include-chrome-extension /client-sso=https://sso.example.com/auth"
 ```
 
 | Parameter | Effect |
 |---|---|
 | `/include-excel` | Installs the Refinitiv Excel addin (COM registration; adds startup time) |
 | `/include-chrome-extension` | Registers the Chrome native messaging host for in-browser charting |
+| `/client-sso=<URL>` | Pre-configures Single Sign-On for Workspace for Web (vendor flag `--client-sso`, documented in the [LSEG Workspace Desktop Installation Guide](https://www.lseg.com/content/dam/data-analytics/en_us/documents/support/workspace/installation.pdf)) |
 
 The installer auto-detects whether the target machine is physical hardware or a VM/VDI guest and selects `--mode=machine` or `--mode=vdi` accordingly.
 
@@ -52,6 +53,7 @@ The chocolatey package modifies the following from Refinitiv's interactive-insta
 | `--shortcut-messenger=false` | Skips the Messenger desktop shortcut (vendor default: create) |
 | `--no-excel` | **Default**: skip the Excel addin install (vendor default: install). Override with `--params "/include-excel"` |
 | `--no-chrome-extension` | **Default**: skip the Chrome native-messaging host (vendor default: install). Override with `--params "/include-chrome-extension"` |
+| `--client-sso=<URL>` | **Optional**: pre-configures Single Sign-On for Workspace for Web. Pass via `--params "/client-sso=<URL>"`. Vendor flag, documented in the LSEG installation guide. |
 
 To re-enable Refinitiv's auto-updater after install, reinstall the application directly via the LSEG website or upgrade via chocolatey when a new package version is published.
 

--- a/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
+++ b/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
@@ -22,40 +22,39 @@ Refinitiv Workspace is the financial analysis desktop and mobile solution, provi
 
 ### Install behaviour
 
-By default the package installs the **core Refinitiv Workspace** only — the Excel addin and Chrome browser extension are skipped. They (and the optional SSO endpoint) can be enabled via chocolatey package parameters:
+By default the package installs **Refinitiv Workspace system-wide** with the Refinitiv auto-updater disabled (`--machine-autoupdate-no`). This matches the typical chocolatey IT-deployment expectation: chocolatey runs the installer as Administrator, so a system-wide install to `%ProgramFiles%\Refinitiv\Refinitiv Workspace` is the correct fit.
+
+Users can override the install mode via package parameters — e.g. `/install-mode=user` for a user-only install (handy when running chocolatey under a personal account), or `/install-mode=machine-service` to install the Refinitiv auto-update Windows service.
+
+#### Available package parameters
 
 ```
-choco install refinitiv-workspace --params "/include-excel /include-chrome-extension /client-sso=https://sso.example.com/auth"
+choco install refinitiv-workspace --params "/install-mode=machine-autoupdate-no /include-excel /client-sso=https://sso.example.com/auth"
 ```
 
 | Parameter | Effect |
 |---|---|
-| `/include-excel` | Installs the Refinitiv Excel addin (COM registration; adds startup time) |
-| `/include-chrome-extension` | Registers the Chrome native messaging host for in-browser charting |
-| `/client-sso=<URL>` | Pre-configures Single Sign-On for Workspace for Web (vendor flag `--client-sso`, documented in the [LSEG Workspace Desktop Installation Guide](https://www.lseg.com/content/dam/data-analytics/en_us/documents/support/workspace/installation.pdf)) |
+| `/install-mode=<mode>` | Override the default user-mode install. Valid values: `user`, `user-no-update`, `machine`, `machine-autoupdate-no`, `machine-service`. See LSEG Installation Guide Appendix C. |
+| `/include-excel` | Pass `--excel` to install the Refinitiv Excel addin (COM registration; off by default to keep installs lean) |
+| `/include-chrome-extension` | Pass `--enable-chrome-extension` to register the Chrome native messaging host (off by default) |
+| `/client-sso=<URL>` | Pre-configure Single Sign-On for Workspace for Web (vendor flag `--client-sso`, [LSEG Installation Guide](https://www.lseg.com/content/dam/data-analytics/en_us/documents/support/workspace/installation.pdf) Appendix C) |
 
-The installer auto-detects whether the target machine is physical hardware or a VM/VDI guest and selects `--mode=machine` or `--mode=vdi` accordingly.
+### Differences from the vendor's interactive defaults
 
-### Differences from the vendor's default install args
-
-The chocolatey package modifies the following from Refinitiv's interactive-installer defaults to make the install non-interactive and minimal-by-default. Run the installer directly from [LSEG's website](https://www.lseg.com/en/data-analytics/products/workspace/download-workspace) if you need the full vendor-default behaviour.
+The chocolatey package passes the following arg set, which differs from running the vendor installer interactively. Run the installer directly from [LSEG's website](https://www.lseg.com/en/data-analytics/products/workspace/download-workspace) if you need fully default vendor behaviour.
 
 | Arg | What it changes vs. vendor default |
 |---|---|
 | `--silent` | Suppresses the install UI (vendor default: interactive) |
-| `--forceInstall` | Installs even if a previous version is present (vendor default: prompt) |
+| `--forceInstall` | Bypasses the System Test prerequisite probe and re-install prompts |
 | `--lang=en` | Pins UI language to English (vendor default: detect from OS) |
-| `--no-update` | Skips the bootstrapper's first-run update check (vendor default: check for newer build before install) |
-| `--machine-autoupdate-no` | Disables the post-install auto-update service (vendor default: install the auto-updater) |
-| `--mode=machine` or `--mode=vdi` | Auto-selected from VM detection (vendor default: prompt for install type) |
-| `--shortcut-workspace=true` | Creates the Workspace desktop shortcut (matches vendor default) |
-| `--shortcut-excel=false` | Skips the Excel-launcher shortcut unless `/include-excel` is passed (vendor default: create) |
-| `--shortcut-messenger=false` | Skips the Messenger desktop shortcut (vendor default: create) |
-| `--no-excel` | **Default**: skip the Excel addin install (vendor default: install). Override with `--params "/include-excel"` |
-| `--no-chrome-extension` | **Default**: skip the Chrome native-messaging host (vendor default: install). Override with `--params "/include-chrome-extension"` |
-| `--client-sso=<URL>` | **Optional**: pre-configures Single Sign-On for Workspace for Web. Pass via `--params "/client-sso=<URL>"`. Vendor flag, documented in the LSEG installation guide. |
+| `--machine-autoupdate-no` (or `/install-mode=...`) | Selects an explicit install mode (system-wide, no auto-update by default). **The vendor's default is interactive prompt for install type.** |
+| `--installerlogpath=<path>` | Writes the installer log into `%TEMP%\refinitiv-workspace\` for diagnostics |
+| `--excel` | **Optional**: only set when `/include-excel` is passed (vendor default: prompts/installs Excel addin) |
+| `--enable-chrome-extension` | **Optional**: only set when `/include-chrome-extension` is passed (vendor default: registers extension) |
+| `--client-sso=<URL>` | **Optional**: pre-configures Single Sign-On for Workspace for Web. Pass via `--params "/client-sso=<URL>"`. |
 
-To re-enable Refinitiv's auto-updater after install, reinstall the application directly via the LSEG website or upgrade via chocolatey when a new package version is published.
+Auto-update behaviour follows the install mode: `user` and `machine-service` modes run a Workspace auto-updater (per-user task or Windows service); `user-no-update` and `machine-autoupdate-no` modes disable it. To change auto-update later, reinstall via the LSEG website or via chocolatey with a different `/install-mode`.
 
 ### Note on the package id rename
 

--- a/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
+++ b/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
@@ -35,14 +35,28 @@ Write-Host "Detected install mode: --mode=$installMode"
 #
 #   choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
 #
-# Both kebab-case (include-excel) and PascalCase (IncludeExcel) accepted.
+# A SSO endpoint URL can also be provided to pre-configure Single Sign-On for
+# Workspace for Web (vendor flag --client-sso, documented in the LSEG
+# Workspace Desktop Installation Guide):
+#
+#   choco install refinitiv-workspace --params "/client-sso=https://sso.example.com/auth"
+#
+# Parameter keys accept both kebab-case (include-excel, client-sso) and
+# PascalCase (IncludeExcel, ClientSso) forms.
 # ---------------------------------------------------------------------------
 $pp = Get-PackageParameters
 $includeExcel  = $pp.ContainsKey('include-excel')           -or $pp.ContainsKey('IncludeExcel')
 $includeChrome = $pp.ContainsKey('include-chrome-extension') -or $pp.ContainsKey('IncludeChromeExtension')
 
+# client-sso accepts a value: /client-sso=<URL>
+$clientSsoUrl = $null
+foreach ($k in 'client-sso','clientsso','ClientSso','ClientSSO') {
+    if ($pp.ContainsKey($k) -and $pp[$k]) { $clientSsoUrl = $pp[$k]; break }
+}
+
 Write-Host ("Excel integration:  " + $(if ($includeExcel)  { 'ENABLED  (--params /include-excel)' }           else { 'disabled (default; pass /include-excel to enable)' }))
 Write-Host ("Chrome extension:   " + $(if ($includeChrome) { 'ENABLED  (--params /include-chrome-extension)' } else { 'disabled (default; pass /include-chrome-extension to enable)' }))
+Write-Host ("Client SSO URL:     " + $(if ($clientSsoUrl)  { "configured ($clientSsoUrl)" }                    else { 'not set (pass /client-sso=<URL> to configure)' }))
 
 # ---------------------------------------------------------------------------
 # Build silent-install args.
@@ -66,6 +80,7 @@ $silentArgList = @(
 )
 if (-not $includeExcel)  { $silentArgList += '--no-excel'; $silentArgList += '--shortcut-excel=false' } else { $silentArgList += '--shortcut-excel=true' }
 if (-not $includeChrome) { $silentArgList += '--no-chrome-extension' }
+if ($clientSsoUrl)       { $silentArgList += "--client-sso=`"$clientSsoUrl`"" }
 
 $silentArgs = $silentArgList -join ' '
 Write-Host "Silent args: $silentArgs"

--- a/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
+++ b/automatic/refinitiv-workspace/tools/chocolateyInstall.ps1
@@ -3,52 +3,52 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsDir\helpers.ps1
 
 # ---------------------------------------------------------------------------
-# Detect physical machine vs virtual machine.
-# Refinitiv Workspace's installer accepts --mode=machine and --mode=vdi.
-# Auto-select based on detected hypervisor presence.
-# ---------------------------------------------------------------------------
-function Test-IsVirtualMachine {
-    try {
-        $cs = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop
-    } catch {
-        return $false
-    }
-    # Common hypervisor / virtualization markers in Manufacturer or Model.
-    $vmPatterns = '(?i)VMware|VirtualBox|innotek|Xen|HVM domU|KVM|QEMU|Parallels|Citrix|Bochs'
-    if ($cs.Model -match $vmPatterns)        { return $true }
-    if ($cs.Manufacturer -match $vmPatterns) { return $true }
-    # Hyper-V / Azure: Microsoft Corporation + 'Virtual Machine' model
-    if ($cs.Manufacturer -eq 'Microsoft Corporation' -and $cs.Model -match 'Virtual Machine') {
-        return $true
-    }
-    return $false
-}
-
-$installMode = if (Test-IsVirtualMachine) { 'vdi' } else { 'machine' }
-Write-Host "Detected install mode: --mode=$installMode"
-
-# ---------------------------------------------------------------------------
-# User-supplied chocolatey package parameters.
+# Install mode selection
 #
-# By default Excel and Chrome integration are NOT installed (faster install,
-# fewer side effects). Users can opt-in via:
+# Default: --machine-autoupdate-no (system-wide install to %ProgramFiles%,
+# no Refinitiv auto-updater). This matches typical IT mass-deployment
+# expectations — chocolatey runs Install-ChocolateyPackage as Administrator
+# via Start-ChocolateyProcessAsAdmin, so a system-wide install is the
+# correct fit (a --user install would land in the admin's %LocalAppData%,
+# not the calling user's profile, which is wrong for chocolatey's model).
 #
-#   choco install refinitiv-workspace --params "/include-excel /include-chrome-extension"
+# Users can override via /install-mode=<mode>:
+#   user, user-no-update, machine, machine-autoupdate-no, machine-service
 #
-# A SSO endpoint URL can also be provided to pre-configure Single Sign-On for
-# Workspace for Web (vendor flag --client-sso, documented in the LSEG
-# Workspace Desktop Installation Guide):
-#
-#   choco install refinitiv-workspace --params "/client-sso=https://sso.example.com/auth"
-#
-# Parameter keys accept both kebab-case (include-excel, client-sso) and
-# PascalCase (IncludeExcel, ClientSso) forms.
+# Valid modes verified via the installer's app.asar argv-key extraction.
+# (Note: VDI mode in the installer is triggered only by --isContinue, not
+# by VM auto-detection, so the System Test skip via --forceInstall works
+# in all default paths.)
 # ---------------------------------------------------------------------------
 $pp = Get-PackageParameters
-$includeExcel  = $pp.ContainsKey('include-excel')           -or $pp.ContainsKey('IncludeExcel')
+
+$installModeOverride = $null
+foreach ($k in 'install-mode','installmode','InstallMode') {
+    if ($pp.ContainsKey($k) -and $pp[$k]) { $installModeOverride = $pp[$k]; break }
+}
+
+$validInstallModes = @('user','user-no-update','machine','machine-autoupdate-no','machine-service')
+if ($installModeOverride -and $validInstallModes -notcontains $installModeOverride) {
+    throw "Invalid /install-mode='$installModeOverride'. Valid values: $($validInstallModes -join ', ')"
+}
+$installMode = if ($installModeOverride) { $installModeOverride } else { 'machine-autoupdate-no' }
+
+Write-Host "Install mode: --$installMode"
+
+# ---------------------------------------------------------------------------
+# Other user-supplied package parameters
+#
+#   /include-excel               — opt in to Refinitiv Excel addin
+#   /include-chrome-extension    — opt in to Chrome native messaging host
+#   /client-sso=<URL>            — pre-configure Single Sign-On endpoint
+#                                   (LSEG Installation Guide, Appendix C)
+#   /install-mode=<mode>         — override default install mode
+#
+# Parameter keys accept both kebab-case and PascalCase forms.
+# ---------------------------------------------------------------------------
+$includeExcel  = $pp.ContainsKey('include-excel')            -or $pp.ContainsKey('IncludeExcel')
 $includeChrome = $pp.ContainsKey('include-chrome-extension') -or $pp.ContainsKey('IncludeChromeExtension')
 
-# client-sso accepts a value: /client-sso=<URL>
 $clientSsoUrl = $null
 foreach ($k in 'client-sso','clientsso','ClientSso','ClientSSO') {
     if ($pp.ContainsKey($k) -and $pp[$k]) { $clientSsoUrl = $pp[$k]; break }
@@ -60,6 +60,16 @@ Write-Host ("Client SSO URL:     " + $(if ($clientSsoUrl)  { "configured ($clien
 
 # ---------------------------------------------------------------------------
 # Build silent-install args.
+#
+# Verified-valid argv keys from the installer's app.asar:
+#   silent, forceInstall, lang, user/machine/<install-mode>, excel,
+#   shortcuts, messengeronly, installerlogpath, machine-autoupdate-no,
+#   machine-service, user-no-update, machine-no-update
+#
+# Removed flags from previous package versions that are NOT recognized as
+# argv keys by the inner Electron arg parser (silently ignored):
+#   --mode=vdi, --no-update, --no-excel, --no-chrome-extension,
+#   --shortcut-workspace, --shortcut-excel, --shortcut-messenger
 # ---------------------------------------------------------------------------
 $UserTemp = $env:TEMP
 $LogPath  = Join-Path $UserTemp $env:ChocolateyPackageName
@@ -69,18 +79,14 @@ if (-not (Test-Path $LogPath)) {
 
 $silentArgList = @(
     '--silent',
-    '--forceInstall',
+    '--forceInstall',          # bypasses System Test on the regular install path
+    "--$installMode",          # explicit install-mode (default: machine-autoupdate-no)
     '--lang=en',
-    '--no-update',
-    '--machine-autoupdate-no',
-    "--mode=$installMode",
-    '--shortcut-workspace=true',
-    '--shortcut-messenger=false',
     "--installerlogpath=`"$LogPath`""
 )
-if (-not $includeExcel)  { $silentArgList += '--no-excel'; $silentArgList += '--shortcut-excel=false' } else { $silentArgList += '--shortcut-excel=true' }
-if (-not $includeChrome) { $silentArgList += '--no-chrome-extension' }
-if ($clientSsoUrl)       { $silentArgList += "--client-sso=`"$clientSsoUrl`"" }
+if ($includeExcel)  { $silentArgList += '--excel' }
+if ($includeChrome) { $silentArgList += '--enable-chrome-extension' }
+if ($clientSsoUrl)  { $silentArgList += "--client-sso=`"$clientSsoUrl`"" }
 
 $silentArgs = $silentArgList -join ' '
 Write-Host "Silent args: $silentArgs"


### PR DESCRIPTION
## Summary

Two changes for `refinitiv-workspace`:

1. **Drop bogus install args** that were being silently ignored by the inner installer's Electron arg parser
2. **Add `/install-mode=<mode>` and `/client-sso=<URL>` opt-in package parameters**

## Correction to my earlier diagnosis

In the previous version of this PR I claimed switching to `--user` would bypass a "VDI auto-detect" branch and fix the 45-min install hang. That was wrong on both counts:

- VDI mode only fires when the installer is invoked with `--isContinue` (a flag we never pass), per the asar code:
  ```js
  l.options.isContinue
      ? setInstallMode(VDI), toContinueInstall    // System Test runs
      : setSkipSystemTest(forceInstall), toInstaller   // skipped via --forceInstall
  ```
- `--user` mode would conflict with chocolatey's admin-elevation context — the install would land in the **admin's** `%LocalAppData%`, not the calling user's, which is wrong for chocolatey's typical IT-deployment model.

So the 45-min hang is most likely just genuine install work running slowly on the moderator's Vagrant Win Server 2019 box (slow disk, slow service registration, slow registry writes for system-wide install). No silent-arg change can shrink that meaningfully.

## What the asar extraction actually fixed

Several flags we were passing **aren't recognized argv keys** — silently no-op'd by the inner Electron yargs parser:

| Bogus flag | Actual asar key |
|---|---|
| `--mode=vdi` | (no key — `mode` doesn't exist as an arg) |
| `--no-update` | only `user-no-update` / `machine-no-update` |
| `--no-excel` | only `excel` (opt-in) |
| `--no-chrome-extension` | (no key) |
| `--shortcut-workspace=true` | only plain `shortcuts` |
| `--shortcut-excel=false` | (no key) |
| `--shortcut-messenger=false` | (no key) |

Removed all of these. Kept only the verified-valid argv keys: `silent`, `forceInstall`, `lang`, `machine-autoupdate-no` (or whatever install-mode the user picks), `installerlogpath`. Plus optional `--excel`, `--enable-chrome-extension`, `--client-sso=<URL>` gated on package params.

## What's actually new

| Aspect | Before | After |
|---|---|---|
| Default install mode | `--machine-autoupdate-no` (was correct, kept) | `--machine-autoupdate-no` (unchanged) |
| `/install-mode=` package param | n/a | New: `user`, `user-no-update`, `machine`, `machine-autoupdate-no`, `machine-service` |
| `/include-excel` | did nothing (passed `--no-excel`, a non-key) | Now passes `--excel` (verified key) |
| `/include-chrome-extension` | did nothing (passed `--no-chrome-extension`, a non-key) | Now passes `--enable-chrome-extension` |
| `/client-sso=<URL>` | n/a | New: passes `--client-sso="<URL>"` |

## Re: the moderator timeout

This PR doesn't claim to fix the chocolatey auto-validator timeout — the underlying 45-min install duration is environmental (Vagrant box speed) and outside our control via silent args. Recommended path is reaching out to chocolatey moderation explaining the situation and requesting manual approval for the package.

## Test plan

- [ ] Merge
- [ ] Re-dispatch refinitiv-workspace: `force_version=1.26.602`, `force=true`, `skip_install_test=true`, `publish=true`
- [ ] Watch chocolatey moderation. If auto-validator times out again, reach out to moderation team via Discord or the package page comments