### PR TITLE
refinitiv-workspace + dell-dract: nuspec hygiene (XML escape + licenseUrl)

### DIFF
--- a/automatic/dell-dract/dell-dract.nuspec
+++ b/automatic/dell-dract/dell-dract.nuspec
@@ -10,6 +10,7 @@
         <docsUrl>https://www.dell.com/support/manuals/en-us/dell-remote-access-config-tool-v1.2/dract_ug_pub-v2/introducing-dell-remote-access-configuration-tool</docsUrl>
         <iconUrl>https://rawcdn.githack.com/mkopnsrc/chocolatey-packages/7bf9b5623b6ca11176bbd2a676a9cf068975d503/icons/dell.png</iconUrl>
         <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/dell-dract</packageSourceUrl>
+        <licenseUrl>https://www.dell.com/learn/us/en/uscorp1/terms-conditions</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <releaseNotes>https://downloads.dell.com/FOLDER02551303M/1/DRACT_1_2_A00_ReleaseNotes.txt</releaseNotes>
         <language>en-US</language>

--- a/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
+++ b/automatic/refinitiv-workspace/refinitiv-workspace.nuspec
@@ -9,6 +9,7 @@
         <projectUrl>https://www.lseg.com/en/data-analytics/products/workspace/download-workspace</projectUrl>
         <iconUrl>https://rawcdn.githack.com/mkopnsrc/chocolatey-packages/f935397734fbcc4c99df70af7ec39e3fcf9115db/icons/refinitive.png</iconUrl>
         <packageSourceUrl>https://github.com/mkopnsrc/chocolatey-packages/tree/master/automatic/refinitiv-workspace</packageSourceUrl>
+        <licenseUrl>https://www.lseg.com/en/policies/website-disclaimer</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <releaseNotes>https://www.lseg.com/en/data-analytics/products/workspace/download-workspace</releaseNotes>
         <language>en-US</language>
@@ -34,10 +35,10 @@ choco install refinitiv-workspace --params "/install-mode=machine-autoupdate-no 
 
 | Parameter | Effect |
 |---|---|
-| `/install-mode=<mode>` | Override the default user-mode install. Valid values: `user`, `user-no-update`, `machine`, `machine-autoupdate-no`, `machine-service`. See LSEG Installation Guide Appendix C. |
+| `/install-mode=&lt;mode&gt;` | Override the default user-mode install. Valid values: `user`, `user-no-update`, `machine`, `machine-autoupdate-no`, `machine-service`. See LSEG Installation Guide Appendix C. |
 | `/include-excel` | Pass `--excel` to install the Refinitiv Excel addin (COM registration; off by default to keep installs lean) |
 | `/include-chrome-extension` | Pass `--enable-chrome-extension` to register the Chrome native messaging host (off by default) |
-| `/client-sso=<URL>` | Pre-configure Single Sign-On for Workspace for Web (vendor flag `--client-sso`, [LSEG Installation Guide](https://www.lseg.com/content/dam/data-analytics/en_us/documents/support/workspace/installation.pdf) Appendix C) |
+| `/client-sso=&lt;URL&gt;` | Pre-configure Single Sign-On for Workspace for Web (vendor flag `--client-sso`, [LSEG Installation Guide](https://www.lseg.com/content/dam/data-analytics/en_us/documents/support/workspace/installation.pdf) Appendix C) |
 
 ### Differences from the vendor's interactive defaults
 
@@ -49,10 +50,10 @@ The chocolatey package passes the following arg set, which differs from running 
 | `--forceInstall` | Bypasses the System Test prerequisite probe and re-install prompts |
 | `--lang=en` | Pins UI language to English (vendor default: detect from OS) |
 | `--machine-autoupdate-no` (or `/install-mode=...`) | Selects an explicit install mode (system-wide, no auto-update by default). **The vendor's default is interactive prompt for install type.** |
-| `--installerlogpath=<path>` | Writes the installer log into `%TEMP%\refinitiv-workspace\` for diagnostics |
+| `--installerlogpath=&lt;path&gt;` | Writes the installer log into `%TEMP%\refinitiv-workspace\` for diagnostics |
 | `--excel` | **Optional**: only set when `/include-excel` is passed (vendor default: prompts/installs Excel addin) |
 | `--enable-chrome-extension` | **Optional**: only set when `/include-chrome-extension` is passed (vendor default: registers extension) |
-| `--client-sso=<URL>` | **Optional**: pre-configures Single Sign-On for Workspace for Web. Pass via `--params "/client-sso=<URL>"`. |
+| `--client-sso=&lt;URL&gt;` | **Optional**: pre-configures Single Sign-On for Workspace for Web. Pass via `--params "/client-sso=&lt;URL&gt;"`. |
 
 Auto-update behaviour follows the install mode: `user` and `machine-service` modes run a Workspace auto-updater (per-user task or Windows service); `user-no-update` and `machine-autoupdate-no` modes disable it. To change auto-update later, reinstall via the LSEG website or via chocolatey with a different `/install-mode`.
 


### PR DESCRIPTION
## Summary

Two related nuspec hygiene fixes:

### 1. XML escaping in refinitiv-workspace description

PR #36's first dispatch failed at the AU update step:

```
Update-Package: ./update.ps1:47
Exception calling "Load" with "1" argument(s):
"The 'URL' start tag on line 55 position 126 does not match
the end tag of 'description'. Line 62, position 11."
```

Bare angle brackets in the description's parameter placeholders (`<URL>`, `<mode>`, `<path>`) tripped AU's `[xml]$nuspec.Load()`. Escaped to `&lt;` / `&gt;` — they still render as `<URL>` / `<mode>` / `<path>` in the chocolatey UI.

Saved a memory entry so future sessions don't repeat this class of error.

### 2. Add `<licenseUrl>` to refinitiv-workspace and dell-dract

Chocolatey nuspec recommendations include a license URL even for proprietary apps. Audit found these two missing it; all other 14 packages in the repo already have `<licenseUrl>` set.

| Package | License URL added |
|---|---|
| `refinitiv-workspace` | `https://www.lseg.com/en/policies/website-disclaimer` (matches the deprecated `refinitive-workspace` stub) |
| `dell-dract` | `https://www.dell.com/learn/us/en/uscorp1/terms-conditions` (Dell's general terms; vendor-specific EULA isn't publicly hosted) |

Both URLs return 403 to bare curl due to vendor bot blocking, but resolve fine in real browsers (which is what chocolatey moderation review uses).

## Test plan

- [ ] Merge
- [ ] Re-dispatch refinitiv-workspace: `force_version=1.26.602`, `force=true`, `skip_install_test=true`, `publish=true` — should pack cleanly with the escaped description and now-present licenseUrl
- [ ] (Side note: dell-dract isn't dispatched in CI; the licenseUrl just lands in master and applies on any future manual rebuild)