### PR TITLE
fonts-poppins: restore missing chocolatey-font-helpers.extension dep

### DIFF
--- a/automatic/fonts-poppins/fonts-poppins.nuspec
+++ b/automatic/fonts-poppins/fonts-poppins.nuspec
@@ -32,6 +32,9 @@ Font files are sourced from the official Google Fonts repository at [github.com/
 
 Licensed under the [SIL Open Font License v1.1](https://scripts.sil.org/OFL). The full license text is shipped under `tools\LICENSE.txt`.</description>
         <summary>Poppins is a geometric sans serif typeface with support for Devanagari and Latin writing systems, shipping 18 static fonts spanning Thin to Black weights in both upright and italic styles.</summary>
+        <dependencies>
+            <dependency id="chocolatey-font-helpers.extension" version="0.0.4" />
+        </dependencies>
     </metadata>
     <files>
         <file src="tools\**" target="tools" />


### PR DESCRIPTION
## Summary

PR #39 dropped the `<dependencies>` block from `fonts-poppins.nuspec` during the rewrite. The first post-merge test (workflow run 25410132799) failed at the install step with:

```
ERROR: The term 'Install-ChocolateyFont' is not recognized
```

This PR restores the dependency at v0.0.4 (the latest on CCR — was 0.0.3.1 before the rewrite).

## Test plan

- [ ] Re-run `package-build-test` against `fonts-poppins` post-merge with `publish=false` to confirm install / verify / uninstall pass.