### PR TITLE
backfill: detect both approval markers (trusted + moderator)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -76,16 +76,17 @@ jobs:
             #
             # The public HTML detail page at /packages/<id>/<version> is
             # consistent across networks and clearly marks moderation state.
-            # Approved versions contain the literal text:
-            #     "This package was approved as"
-            # Pending versions never contain that text. Rejected versions
-            # contain "rejected by" near "package".
+            # CCR uses two distinct approval messages — both indicate Approved:
+            #   "This package was approved as a trusted package..." (auto, trusted maintainer)
+            #   "This package was approved by moderator <name>..."  (human review)
+            # Pending versions contain neither. Rejected versions contain
+            # "rejected by" near "moderator".
             function Get-CcrApprovalState($pkg, $version) {
               $url = "https://community.chocolatey.org/packages/$pkg/$version"
               try {
                 $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -UserAgent 'mkopnsrc-backfill/1.0'
                 $html = $resp.Content
-                if ($html -match 'This package was approved as') { return 'Approved' }
+                if ($html -match 'This package was approved (as|by moderator)') { return 'Approved' }
                 if ($html -match 'rejected by .{0,40}moderator') { return 'Rejected' }
                 # Page exists, no approved/rejected marker → still in queue
                 return 'Pending'


### PR DESCRIPTION
## Summary

CCR uses two distinct approval messages, and the backfill cron's `Get-CcrApprovalState` only matched the first one:

| HTML marker | Used for | Detected by old regex? |
|---|---|---|
| `This package was approved as a trusted package...` | Auto-approvals on trusted maintainers (Beats series) | ✅ yes |
| `This package was approved by moderator <name>...` | Human moderator review (new packages) | ❌ no |

So the cron has been silently misreporting moderator-approved versions as still-Pending and refusing to advance the plan.

## Concrete impact

`auditbeat-oss/8.19.14` was approved by moderator `flcdrg` on 2026-05-23. The cron has run on every ~6h cadence since then (10+ runs) and each one logged:

```
auditbeat-oss : 8.19.14=Pending, 9.3.0=NotPushed, ...
::notice::auditbeat-oss : highest pushed version 8.19.14 is Pending — skipping this cycle
```

The four follow-on versions (`9.3.0`, `9.3.1`, `9.3.2`, `9.3.3`) have been stuck waiting to push for ~5 days.

## Fix

Combine both markers in one regex alternation:

```diff
- if ($html -match 'This package was approved as') { return 'Approved' }
+ if ($html -match 'This package was approved (as|by moderator)') { return 'Approved' }
```

## Test plan

- [ ] After merge, watch the next scheduled cron run (or trigger one manually via `workflow_dispatch` on `backfill.yml`) and confirm:
  - `auditbeat-oss : 8.19.14=Approved, 9.3.0=NotPushed, ...`
  - `::notice::auditbeat-oss : queueing push for version 9.3.0`
- [ ] Confirm the resulting push job runs and `auditbeat-oss/9.3.0` lands in CCR.