### PR TITLE
fix fluent-bit: sync embedded MSI outside AU au_BeforeUpdate hook

### DIFF
--- a/automatic/fluent-bit/update.ps1
+++ b/automatic/fluent-bit/update.ps1
@@ -2,64 +2,50 @@ Import-Module au
 
 # Fluent Bit publishes Windows binaries at https://packages.fluentbit.io/windows/
 # alongside a version-in-URL scheme. The docs page names the current version.
-# We scrape that page for the version, download the win64 .msi at build time,
-# embed it inside tools\, and record its SHA256 in VERIFICATION.txt.
-$docsPage = 'https://docs.fluentbit.io/manual/installation/downloads/windows'
-$cdnBase  = 'https://packages.fluentbit.io/windows'
-$licenseUrl = 'https://raw.githubusercontent.com/fluent/fluent-bit/master/LICENSE'
+#
+# Design: we sync the embedded MSI (download + refresh VERIFICATION/LICENSE)
+# BEFORE calling AU's `update`, because AU short-circuits `au_BeforeUpdate`
+# when nuspec version already matches remote — and we still want the binary
+# present in tools\ every time the workflow runs (fresh runner starts empty).
 
-function global:au_GetLatest {
-    if ($global:au_Version) {
-        $version = $global:au_Version
-    } else {
-        $page = Invoke-WebRequest -Uri $docsPage -UseBasicParsing
-        $m = [regex]::Match($page.Content, 'fluent-bit-(\d+\.\d+\.\d+)-win64\.msi')
-        if (-not $m.Success) { throw "Could not locate a win64 MSI version on $docsPage" }
-        $version = $m.Groups[1].Value
-    }
+$docsPage    = 'https://docs.fluentbit.io/manual/installation/downloads/windows'
+$cdnBase     = 'https://packages.fluentbit.io/windows'
+$licenseUrl  = 'https://raw.githubusercontent.com/fluent/fluent-bit/master/LICENSE'
 
-    $msiFilename = "fluent-bit-$version-win64.msi"
-    $url         = "$cdnBase/$msiFilename"
-
-    # Fail loudly if the CDN doesn't actually have this version's binary yet
-    # (vendor sometimes tags a version on GitHub before publishing binaries).
-    try {
-        $head = Invoke-WebRequest -Uri $url -Method Head -UseBasicParsing
-        if ($head.StatusCode -ne 200) { throw "HEAD $url returned $($head.StatusCode)" }
-    } catch {
-        throw "Vendor CDN does not yet serve $msiFilename — skipping this cycle. $_"
-    }
-
-    @{
-        URL64        = $url
-        Version      = $version
-        MsiFilename  = $msiFilename
-    }
+function Get-FluentBitVersion {
+    if ($global:au_Version) { return $global:au_Version }
+    $page = Invoke-WebRequest -Uri $docsPage -UseBasicParsing
+    $m = [regex]::Match($page.Content, 'fluent-bit-(\d+\.\d+\.\d+)-win64\.msi')
+    if (-not $m.Success) { throw "Could not locate a win64 MSI version on $docsPage" }
+    return $m.Groups[1].Value
 }
 
-function global:au_BeforeUpdate {
-    $toolsDir = Join-Path $PSScriptRoot 'tools'
-    if (-not (Test-Path $toolsDir)) { New-Item -ItemType Directory -Path $toolsDir | Out-Null }
+# --- Sync embedded binary + auxiliary files (always runs) -------------------
 
-    # Purge any prior MSI so we don't ship two.
-    Get-ChildItem -Path $toolsDir -Filter 'fluent-bit-*-win64.msi' -ErrorAction SilentlyContinue |
-        Remove-Item -Force
+$version     = Get-FluentBitVersion
+$msiFilename = "fluent-bit-$version-win64.msi"
+$msiUrl      = "$cdnBase/$msiFilename"
 
-    $msiPath = Join-Path $toolsDir $Latest.MsiFilename
-    Write-Host "Downloading $($Latest.URL64) -> $msiPath"
-    Invoke-WebRequest -Uri $Latest.URL64 -OutFile $msiPath -UseBasicParsing
+$toolsDir = Join-Path $PSScriptRoot 'tools'
+if (-not (Test-Path $toolsDir)) { New-Item -ItemType Directory -Path $toolsDir | Out-Null }
 
-    $sha = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash.ToLowerInvariant()
-    $Latest.Checksum64 = $sha
-    Write-Host "SHA256($($Latest.MsiFilename)) = $sha"
+# Purge any stale MSI(s) from a prior version.
+Get-ChildItem -Path $toolsDir -Filter 'fluent-bit-*-win64.msi' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -ne $msiFilename } |
+    Remove-Item -Force
 
-    # Refresh Apache 2.0 license text bundled with the package.
-    $licensePath = Join-Path $toolsDir 'LICENSE.txt'
-    Invoke-WebRequest -Uri $licenseUrl -OutFile $licensePath -UseBasicParsing
+$msiPath = Join-Path $toolsDir $msiFilename
+Write-Host "Downloading $msiUrl -> $msiPath"
+Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath -UseBasicParsing
 
-    # Regenerate VERIFICATION.txt with the fresh URL + SHA so it always matches
-    # the currently-embedded MSI.
-    $verification = @"
+$sha = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash.ToLowerInvariant()
+Write-Host "SHA256($msiFilename) = $sha"
+
+# Refresh Apache 2.0 license bundled with the package.
+Invoke-WebRequest -Uri $licenseUrl -OutFile (Join-Path $toolsDir 'LICENSE.txt') -UseBasicParsing
+
+# Regenerate VERIFICATION.txt so the recorded SHA always matches the embedded MSI.
+$verification = @"
 VERIFICATION
 Verification is intended to assist reviewers in confirming that this
 package's embedded binary is trustworthy.
@@ -68,7 +54,7 @@ The MSI shipped inside this package's tools\ directory was downloaded at
 build time directly from the Fluent Bit project's official CDN:
 
   Upstream MSI URL:
-    $($Latest.URL64)
+    $msiUrl
 
   Vendor:         Chronosphere Inc. (Author field of the MSI)
   Vendor page:    https://docs.fluentbit.io/manual/installation/downloads/windows
@@ -80,14 +66,14 @@ build time directly from the Fluent Bit project's official CDN:
 To reproduce the SHA256 locally:
 
   PowerShell:
-    `$u = '$($Latest.URL64)'
+    `$u = '$msiUrl'
     `$t = Join-Path `$env:TEMP 'fluent-bit.msi'
     Invoke-WebRequest -Uri `$u -OutFile `$t -UseBasicParsing
     Get-FileHash `$t -Algorithm SHA256
 
   Linux/macOS:
-    curl -sLO '$($Latest.URL64)'
-    sha256sum $($Latest.MsiFilename)
+    curl -sLO '$msiUrl'
+    sha256sum $msiFilename
 
 Note: the vendor does not publish an official .sha256 sidecar for the
 .msi variant (only for the .exe variant). The hash above was computed
@@ -96,12 +82,20 @@ locally against the MSI as served by the CDN at package build time.
 License: Apache License 2.0 (see LICENSE.txt bundled in this package
 and the canonical text at https://github.com/fluent/fluent-bit/blob/master/LICENSE).
 "@
-    $verification | Set-Content -Path (Join-Path $toolsDir 'VERIFICATION.txt') -Encoding UTF8
+Set-Content -Path (Join-Path $toolsDir 'VERIFICATION.txt') -Value $verification -Encoding UTF8
+
+# --- AU version bump for the nuspec ----------------------------------------
+
+function global:au_GetLatest {
+    @{
+        Version = $version
+        URL64   = $msiUrl
+    }
 }
 
 function global:au_SearchReplace {
-    # Nuspec version is auto-updated by AU. Nothing to rewrite in install/uninstall
-    # scripts because they globbing-discover the MSI (`fluent-bit-*-win64.msi`).
+    # No install-script edits needed — chocolateyInstall.ps1 glob-discovers
+    # the MSI. AU handles the nuspec version bump automatically.
     @{}
 }
 


### PR DESCRIPTION
## Summary
Follow-up fix for the fluent-bit package added in #47. The first smoke test dispatch (workflow run [30595021312](https://github.com/mkopnsrc/chocolatey-packages/actions/runs/30595021312)) failed at the install step with:

```
ERROR: No embedded fluent-bit MSI found under C:\ProgramData\chocolatey\lib\fluent-bit\tools. Package is malformed.
```

## Root cause
AU's `Update-Package` short-circuits when the nuspec version already matches the remote version:

```
nuspec version: 5.0.8
remote version: 5.0.8
No new version found
Updated: False
```

When AU short-circuits, it also **skips `au_BeforeUpdate`** — so the MSI never got downloaded. The initial nuspec was committed at 5.0.8 (matching current upstream), which put us straight into the short-circuit path and produced a 9.7 KB nupkg with no binary.

## Fix
Moved the MSI download + `LICENSE.txt` + `VERIFICATION.txt` regeneration out of `au_BeforeUpdate` and up to **top-level** in `update.ps1`. That way the embedded binary is always synced on every dispatch, regardless of AU's version-comparison decision. AU still handles the nuspec version bump when the vendor moves forward.

The fonts-poppins package doesn't hit this because its initial version was ahead of the nuspec at commit time, so AU always saw a bump. This one had matching versions on day one, exposing the assumption.

## Test plan
- [ ] Merge, then re-dispatch `Publish nupkg to GitHub Releases` for `fluent-bit` with `publish_release=false`. Expect the nupkg to be ~25 MB (embedded MSI) and install/verify/uninstall to complete.