### PR TITLE
automated: backfill 2026-07-29-1245 (1 packages) — rebased

### DIFF
--- a/automatic/auditbeat-oss/auditbeat-oss.nuspec
+++ b/automatic/auditbeat-oss/auditbeat-oss.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
     <metadata>
         <id>auditbeat-oss</id>
-        <version>9.3.1</version>
+        <version>9.3.2</version>
         <title>Auditbeat - OSS</title>
         <authors>ElasticSearch</authors>
         <owners>opnsrc.dev</owners>

--- a/automatic/auditbeat-oss/tools/chocolateyInstall.ps1
+++ b/automatic/auditbeat-oss/tools/chocolateyInstall.ps1
@@ -8,11 +8,11 @@ $packageArgs = @{
     version         = $env:ChocolateyPackageVersion
     unzipLocation   = $toolsDir
     installerType   = 'msi'
-    url             = 'https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-9.3.1-windows-x86_64.msi'
-    url64bit        = 'https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-9.3.1-windows-x86_64.msi'
-    checksum        = 'b97df66c2ccf603462195ba779838655928fdb4ef8c44e3c51f135fa539e2a5c'
+    url             = 'https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-9.3.2-windows-x86_64.msi'
+    url64bit        = 'https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-9.3.2-windows-x86_64.msi'
+    checksum        = '5857edfbce2b9371e2ae11ba30cffefe463e7d175a51503c7d38415954a7b833'
     checksumType    = 'SHA256'
-    checksum64      = 'b97df66c2ccf603462195ba779838655928fdb4ef8c44e3c51f135fa539e2a5c'
+    checksum64      = '5857edfbce2b9371e2ae11ba30cffefe463e7d175a51503c7d38415954a7b833'
     checksumType64  = 'SHA256'
     silentArgs      = "/qn /norestart"
     #Exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx


### PR DESCRIPTION
Replaces #46, which conflicted with master after PR #45 landed `9.3.1` in between.

## Summary
Syncs the repo files with what was already pushed to chocolatey.org on 2026-07-29:

- `auditbeat-oss` → **9.3.2** (currently `Submitted` in CCR moderation).

## Verification
- MSI URL: `https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-oss-9.3.2-windows-x86_64.msi`
- SHA256: `5857edfbce2b9371e2ae11ba30cffefe463e7d175a51503c7d38415954a7b833`
- CCR listing: https://community.chocolatey.org/packages/auditbeat-oss/9.3.2

Each backfill push was install-tested on a fresh `windows-2022` runner before submission (see run history under `.github/workflows/backfill.yml`). Merging this PR has no publishing side-effect — CCR moderation for 9.3.2 already advanced.