### PR TITLE
publish-nupkg-release: sleet retention needs --prerelease too

### DIFF
--- a/.github/workflows/publish-nupkg-release.yml
+++ b/.github/workflows/publish-nupkg-release.yml
@@ -206,6 +206,7 @@ jobs:
           REPO: ${{ github.repository }}
           FEED_BASE_URI: https://mkopnsrc.github.io/chocolatey-packages/nuget/
           RETENTION_STABLE: '5'
+          RETENTION_PRERELEASE: '0'
         run: |
           $nupkg = (Get-ChildItem $env:RUNNER_TEMP\*.nupkg | Select-Object -First 1).FullName
 
@@ -262,7 +263,9 @@ jobs:
             New-Item -ItemType Directory -Path $feedPath -Force | Out-Null
             sleet init --config $sleetConfig
             if ($LASTEXITCODE -ne 0) { throw "sleet init failed" }
-            sleet retention settings --stable $env:RETENTION_STABLE --config $sleetConfig
+            # sleet requires BOTH --stable AND --prerelease even if the intent
+            # is stable-only (0 prerelease = drop all prerelease versions).
+            sleet retention settings --stable $env:RETENTION_STABLE --prerelease $env:RETENTION_PRERELEASE --config $sleetConfig
             if ($LASTEXITCODE -ne 0) { throw "sleet retention settings failed" }
           }
 


### PR DESCRIPTION
Follow-up fix for #55.

Bootstrap run [30678691670](https://github.com/mkopnsrc/chocolatey-packages/actions/runs/30678691670) reached sleet, but failed on:

\`\`\`
[System.ArgumentException] Missing required parameter --prerelease.
\`\`\`

Sleet's \`retention settings\` command treats both \`--stable\` AND \`--prerelease\` as required, even when the intent is stable-only. Fixed by passing \`--prerelease 0\` (drop all prerelease versions) alongside \`--stable 5\`. Added a \`RETENTION_PRERELEASE\` env var to keep the two knobs together.

## Fallout audit
The run failed BEFORE the git commit step, so \`gh-pages\` was never created — no bootstrap side effect to unwind. Merging this + re-dispatching will bootstrap cleanly on the retry.