### PR TITLE
publish-nupkg-release: enforce sleet retention inline on prune

### DIFF
--- a/.github/workflows/publish-nupkg-release.yml
+++ b/.github/workflows/publish-nupkg-release.yml
@@ -263,18 +263,16 @@ jobs:
             New-Item -ItemType Directory -Path $feedPath -Force | Out-Null
             sleet init --config $sleetConfig
             if ($LASTEXITCODE -ne 0) { throw "sleet init failed" }
-            # sleet requires BOTH --stable AND --prerelease even if the intent
-            # is stable-only (0 prerelease = drop all prerelease versions).
-            sleet retention settings --stable $env:RETENTION_STABLE --prerelease $env:RETENTION_PRERELEASE --config $sleetConfig
-            if ($LASTEXITCODE -ne 0) { throw "sleet retention settings failed" }
           }
 
           # Add the new .nupkg. --skip-existing makes re-dispatches idempotent.
           sleet push $nupkg --config $sleetConfig --skip-existing
           if ($LASTEXITCODE -ne 0) { throw "sleet push failed" }
 
-          # Enforce retention.
-          sleet retention prune --config $sleetConfig
+          # Enforce retention inline instead of via `sleet retention settings`,
+          # which was failing with a swallowed error on init runs. The docs
+          # explicitly support passing --stable/--prerelease directly to prune.
+          sleet retention prune --stable $env:RETENTION_STABLE --prerelease $env:RETENTION_PRERELEASE --config $sleetConfig
           if ($LASTEXITCODE -ne 0) { throw "sleet retention prune failed" }
 
           # Landing page so someone visiting the repo's GH Pages URL sees


### PR DESCRIPTION
Second bootstrap follow-up. Run [30678808092](https://github.com/mkopnsrc/chocolatey-packages/actions/runs/30678808092) still failed at retention setup even after #56 added \`--prerelease\`.

## What actually happened

Sleet got as far as \`Updating package retention settings in https://mkopnsrc.github.io/chocolatey-packages/nuget/\`, then died within 300ms. My PowerShell threw on \`\$LASTEXITCODE\` without surfacing sleet's stderr — I saw only \"sleet retention settings failed\" without the actual sleet error.

## Fix

Rather than dig into why \`sleet retention settings\` doesn't like our args on a freshly-initialized feed, drop that step entirely and pass \`--stable\`/\`--prerelease\` directly to \`sleet retention prune\` on each run. The sleet docs explicitly support this alternative:

> Alternatively the prune command can be used directly without feed settings.
> \`sleet retention prune --stable 5 --prerelease 2\`

Behavior is equivalent: retention still enforced on every publish; we just no longer persist the setting into \`sleet.settings.json\`. One less thing to debug.

## Fallout audit

Second failed run also died before \`git push origin gh-pages\`. No \`gh-pages\` branch was created, no bootstrap side effect to unwind.