### PR TITLE
publish-nupkg-release: sleet retention rejects --prerelease 0

### DIFF
--- a/.github/workflows/publish-nupkg-release.yml
+++ b/.github/workflows/publish-nupkg-release.yml
@@ -206,7 +206,10 @@ jobs:
           REPO: ${{ github.repository }}
           FEED_BASE_URI: https://mkopnsrc.github.io/chocolatey-packages/nuget/
           RETENTION_STABLE: '5'
-          RETENTION_PRERELEASE: '0'
+          # sleet rejects --prerelease 0 with "must specify a maximum number
+          # of prerelease versions that is > 0"; embedded-binary packages here
+          # don't ship prereleases so 1 is a functional no-op.
+          RETENTION_PRERELEASE: '1'
         run: |
           $nupkg = (Get-ChildItem $env:RUNNER_TEMP\*.nupkg | Select-Object -First 1).FullName
 


### PR DESCRIPTION
Third bootstrap follow-up. Run [30678999732](https://github.com/mkopnsrc/chocolatey-packages/actions/runs/30678999732) finally surfaced sleet's real error:

\`\`\`
[System.ArgumentException] Package retention must specify a maximum number of prerelease versions that is > 0
\`\`\`

Sleet rejects \`--prerelease 0\` even for stable-only feeds. Bump \`RETENTION_PRERELEASE\` from 0 → 1; a functional no-op since embedded-binary packages here don't ship prereleases.

## Good news from the same run
\`sleet init\` + \`sleet push\` both worked cleanly. 8 files (23.76 MB — flatcontainer, registration, search, autocomplete) were written to the local worktree. Only the subsequent \`prune\` failed, before the git commit/push step, so still no \`gh-pages\` branch to unwind.

## Fallout audit
All three failed bootstrap runs (30678691670, 30678808092, 30678999732) died before \`git push origin gh-pages\`. No partial state on the remote.